### PR TITLE
Increase Granularity of Allowed Return Status

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,10 @@ following format:
 {
   "tool_name": {
     "solidity_file": {
-      "contract_name": <time_taken>
+      "contract_name": {
+        "result": <safe/unsafe/unknown>,
+        "time_taken": <time taken (ms)>
+      }
     }
   }
 }
@@ -51,7 +54,11 @@ In order to include a tool in this repository, you should add a script for that 
 
 This script should have the signature: `tools/SCRIPT_NAME <contract_file> <contract_name>`.
 
-It should output a single `1` to stdout for unsafe contracts and a `0` for safe contracts.
+It should output:
+
+- "safe": if the contract contains no reachable assertion violations
+- "unsafe": if the contract contains at least one reachable assertion violation
+- "unknown": if the tool was unable to determine whether a reachable assertion violation is present
 
 Before executing the benchmarks, `forge build` is invoked on all Solidity files in the repository, and
 tools that operate on EVM bytecode can read the compiled bytecode directly from the forge build

--- a/bench.py
+++ b/bench.py
@@ -4,7 +4,7 @@ import subprocess
 import os
 import glob
 from pathlib import Path
-import timeit
+import time
 import copy
 import json
 
@@ -29,9 +29,10 @@ for t, script in tools.items():
     for file, contracts in results[t].items():
         results[t][file] = {}
         for c in contracts:
-            results[t][file][c] = timeit.timeit(
-                lambda: subprocess.run([script, file, c]), number=1
-            )
+            before = time.time_ns()
+            res = subprocess.run([script, file, c], capture_output=True, encoding="utf-8")
+            after = time.time_ns()
+            results[t][file][c] = { "result": res.stdout.rstrip(), "time_taken": (after - before) // 1000000 }
 
 # write the results to disk as json
 with open('results.json', 'w') as res:


### PR DESCRIPTION
- tool harnesses should now report a contract as either `safe`/`unsafe`/`unknown`
- this reported status is included in the results.json file