### PR TITLE
Move to `doalarm`, fix graph location, remove crytic, move to newer hamos

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,19 @@ consume Solidity, Yul, or EVM bytecode.
 The benchmarks in this repo should be useful to developers of all kinds of
 tools, including fuzzers, static analyzers, and symbolic execution engines.
 
+### Quick Start Guide
+
+Install nix (see [here](https://nixos.org/download.html)). Then:
+
+```
+sudo nix-shell -p cachix --command "cachix use k-framework"
+nix develop   # this make take some time
+./bench.py --tools all
+./gen_graphs.py
+cd graphs
+```
+
+You can look at the graphs under the folder `graphs`
 
 ## Using This Repository
 
@@ -17,20 +30,15 @@ all tools required to run the benchmarks. If you want to add a new tool then
 you need to extend the `flake.nix` so that this tool is present in the
 `devShell`.
 
-To enter the environment, run `nix develop`. If it's your first time running
-this command you will be prompted to ask if you want to allow changes to the
-configuration settings for `extra-substituters` and `extra-trusted-public-keys`.
-If you accept these changes the runtime verification binary cache will be used
-when building `kevm`. This should significantly speed up the time it takes to
-prepare the environment.
+To enter the environment, run `nix develop`. Once you have a working shell, you
+can run `python bench.py` to execute the benchmarks. The results are collected
+in `results.db` sqlite3 database and the csv and json files
+`results-[timestamp].csv/json`. You can view these files using standard tools
+such as libreoffice, Excel, jq, etc.
 
-Once you have a working shell, you can run `python bench.py` to execute the
-benchmarks. The results are collected in `results.db` sqlite3 database and the
-csv and json files `results-[timestamp].csv/json`.
-
-To generate graphs, run `python gen_graph.py`.  For example, you can
+To generate graphs, run `python gen_graph.py`.  Then, you can
 look at the cumulative distribution function (CDF) graph to get an overview.
-Here, the different tools's performances are displayed, with X axis showing
+Here, the different tools' performances are displayed, with X axis showing
 time, and the Y axis showing the number of problems solved within that time
 frame. Typically, a tool is be better when it solves more instances (i.e.
 higher on the Y axis) while being faster (i.e. more to the left on the X axis)
@@ -108,11 +116,10 @@ Your main shell script should output:
 - "unsafe": if the contract contains at least one reachable assertion violation
 - "unknown": if the tool was unable to determine whether a reachable assertion violation is present
 
-Before executing the benchmarks, either `forge build` or `python crytic compile`
-(configurable in bench.py) is invoked on all Solidity files in the repository,
-and tools that operate on EVM bytecode can read the compiled bytecode directly
-from the respective build outputs.
+Before executing the benchmarks, `forge build` is invoked on all Solidity files
+in the repository, and tools that operate on EVM bytecode can read the compiled
+bytecode directly from the respective build outputs.
 
 Check out the examples for `hevm` and `halmos` in the repository for examples.
-Note that in order for others to run your tool, it
-needs to be added to `flake.nix`.
+Note that in order for others to run your tool, it needs to be added to
+`flake.nix`.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Install nix (see [here](https://nixos.org/download.html)). Then:
 ```
 sudo nix-shell -p cachix --command "cachix use k-framework"
 nix develop   # this make take some time
-./bench.py --tools all
+./bench.py
 ./gen_graphs.py
 cd graphs
 ```

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Install nix (see [here](https://nixos.org/download.html)). Then:
 
 ```
 sudo nix-shell -p cachix --command "cachix use k-framework"
-nix develop   # this make take some time
+nix develop   # this may take some time
 ./bench.py
 ./gen_graphs.py
 cd graphs

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ tools, including fuzzers, static analyzers, and symbolic execution engines.
 Install nix (see [here](https://nixos.org/download.html)). Then:
 
 ```
+# optional, but will make subsequent steps significantly faster
 sudo nix-shell -p cachix --command "cachix use k-framework"
 nix develop   # this may take some time
 ./bench.py

--- a/bench.py
+++ b/bench.py
@@ -222,7 +222,7 @@ def execute_case(tool: str, extra_opts: list[str], case: Case) -> Result:
     before = time.time_ns()
     fname_time = unique_file("output")
     toexec = ["time", "--verbose", "-o", "%s" % fname_time,
-              tool, case.sol_file, case.contract, case.fun, "%i" % case.ds]
+              tool, case.sol_file, case.contract, case.fun, "%i" % case.ds, "%s" % opts.timeout]
     toexec.extend(extra_opts)
     print("Running: %s" % (" ".join(toexec)))
     res = subprocess.run(toexec, capture_output=True, encoding="utf-8")

--- a/bench.py
+++ b/bench.py
@@ -26,7 +26,9 @@ def build_forge() -> None:
     print("Building with forge...")
     if not opts.norebuild:
         recreate_out()
-        ret = subprocess.run(["forge", "build", "--use", opts.solc_version], capture_output=True)
+        ret = subprocess.run(["forge", "build", "--extra-output",
+                              "storageLayout", "metadata", "--use",
+                              opts.solc_version], capture_output=True)
         if ret.returncode != 0:
             print("Forge returned error(s)")
             print(printable_output(ret.stderr))

--- a/bench.py
+++ b/bench.py
@@ -220,11 +220,8 @@ def execute_case(tool: str, extra_opts: list[str], case: Case) -> Result:
     result = None
     res = None
     before = time.time_ns()
-    fname_runlim = unique_file("output")
     fname_time = unique_file("output")
-    toexec = ["time", "--verbose", "-o", "%s" % fname_time, "runlim",
-              "--real-time-limit=%s" % opts.timeout, "--output-file=%s" % fname_runlim,
-              "--kill-delay=10",
+    toexec = ["time", "--verbose", "-o", "%s" % fname_time,
               tool, case.sol_file, case.contract, case.fun, "%i" % case.ds]
     toexec.extend(extra_opts)
     print("Running: %s" % (" ".join(toexec)))
@@ -235,15 +232,9 @@ def execute_case(tool: str, extra_opts: list[str], case: Case) -> Result:
     exit_status = None
     perc_CPU = None
 
-    # parse runlim output
-    with open(fname_runlim, 'r') as f:
-        for l in f:
-            # if opts.verbose: print("runlim output line: ", l.strip())
-            if re.match("^.runlim. status:.*out of time", l):
-                out_of_time = True
     if opts.verbose:
-            print("Res stdout is:", res.stdout)
-            print("Res stderr is:", res.stderr)
+        print("Res stdout is:", res.stdout)
+        print("Res stderr is:", res.stderr)
     for l in res.stdout.split("\n"):
         l = l.strip()
         match = re.match("result: (.*)$", l)
@@ -270,7 +261,6 @@ def execute_case(tool: str, extra_opts: list[str], case: Case) -> Result:
                 exit_status = int(match.group(1))
 
     assert result == "safe" or result == "unsafe" or result == "unknown"
-    os.unlink(fname_runlim)
     os.unlink(fname_time)
     if opts.verbose:
         print("Result is: ", result)

--- a/bench.py
+++ b/bench.py
@@ -360,7 +360,7 @@ def set_up_parser() -> optparse.OptionParser:
                       dest="verbose", help="More verbose output. Default: %default")
 
     parser.add_option("-s", dest="seed", type=int, default=1,
-                      help="Seed for random numbers for reproducibility. Default: %default")
+                      help="Seed for random numbers. Default: %default")
 
     parser.add_option("--solcv", dest="solc_version", type=str, default="0.8.19",
                       help="solc version to use to compile contracts")

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,227 @@
 {
   "nodes": {
+    "HTTP": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1451647621,
+        "narHash": "sha256-oHIyw3x0iKBexEo49YeUDV1k74ZtyYKGR2gNJXXRxts=",
+        "owner": "phadej",
+        "repo": "HTTP",
+        "rev": "9bc0996d412fef1787449d841277ef663ad9a915",
+        "type": "github"
+      },
+      "original": {
+        "owner": "phadej",
+        "repo": "HTTP",
+        "type": "github"
+      }
+    },
+    "HTTP_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1451647621,
+        "narHash": "sha256-oHIyw3x0iKBexEo49YeUDV1k74ZtyYKGR2gNJXXRxts=",
+        "owner": "phadej",
+        "repo": "HTTP",
+        "rev": "9bc0996d412fef1787449d841277ef663ad9a915",
+        "type": "github"
+      },
+      "original": {
+        "owner": "phadej",
+        "repo": "HTTP",
+        "type": "github"
+      }
+    },
+    "ate-pairing": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1499347915,
+        "narHash": "sha256-IMfWgKkkX7UcUaOPtGRcYD8MdVEP5Z9JOOSJ4+P07G8=",
+        "owner": "herumi",
+        "repo": "ate-pairing",
+        "rev": "e69890125746cdaf25b5b51227d96678f76479fe",
+        "type": "github"
+      },
+      "original": {
+        "owner": "herumi",
+        "repo": "ate-pairing",
+        "rev": "e69890125746cdaf25b5b51227d96678f76479fe",
+        "type": "github"
+      }
+    },
+    "blockchain-k-plugin": {
+      "inputs": {
+        "ate-pairing": "ate-pairing",
+        "cpp-httplib": "cpp-httplib",
+        "cryptopp": "cryptopp",
+        "flake-utils": [
+          "kevm",
+          "k-framework",
+          "flake-utils"
+        ],
+        "libff": "libff",
+        "nixpkgs": [
+          "kevm",
+          "k-framework",
+          "nixpkgs"
+        ],
+        "secp256k1": "secp256k1",
+        "xbyak": "xbyak"
+      },
+      "locked": {
+        "lastModified": 1689159696,
+        "narHash": "sha256-dGICJl8YAWXjpjeY1rcRMLyWka3kMZmW74B6q3gvrhQ=",
+        "owner": "runtimeverification",
+        "repo": "blockchain-k-plugin",
+        "rev": "da834be67f6c0aff11140ddfc0b04561494c14b8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "runtimeverification",
+        "repo": "blockchain-k-plugin",
+        "rev": "da834be67f6c0aff11140ddfc0b04561494c14b8",
+        "type": "github"
+      }
+    },
+    "booster-backend": {
+      "inputs": {
+        "flake-compat": "flake-compat_3",
+        "haskell-backend": "haskell-backend",
+        "haskell-nix": [
+          "kevm",
+          "k-framework",
+          "booster-backend",
+          "haskell-backend",
+          "haskell-nix"
+        ],
+        "k-framework": [
+          "kevm",
+          "k-framework"
+        ],
+        "nixpkgs": [
+          "kevm",
+          "k-framework",
+          "haskell-backend",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1689643858,
+        "narHash": "sha256-NYs4Y4+2xfqSXjsxt/QwECK1eZ0zY2EDLUPj9a732N4=",
+        "owner": "runtimeverification",
+        "repo": "hs-backend-booster",
+        "rev": "a258fe8932da8c5cffab1c1bfbe18b99730cacd8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "runtimeverification",
+        "repo": "hs-backend-booster",
+        "rev": "a258fe8932da8c5cffab1c1bfbe18b99730cacd8",
+        "type": "github"
+      }
+    },
+    "cabal-32": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1603716527,
+        "narHash": "sha256-X0TFfdD4KZpwl0Zr6x+PLxUt/VyKQfX7ylXHdmZIL+w=",
+        "owner": "haskell",
+        "repo": "cabal",
+        "rev": "48bf10787e27364730dd37a42b603cee8d6af7ee",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "3.2",
+        "repo": "cabal",
+        "type": "github"
+      }
+    },
+    "cabal-32_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1603716527,
+        "narHash": "sha256-X0TFfdD4KZpwl0Zr6x+PLxUt/VyKQfX7ylXHdmZIL+w=",
+        "owner": "haskell",
+        "repo": "cabal",
+        "rev": "48bf10787e27364730dd37a42b603cee8d6af7ee",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "3.2",
+        "repo": "cabal",
+        "type": "github"
+      }
+    },
+    "cabal-34": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1645834128,
+        "narHash": "sha256-wG3d+dOt14z8+ydz4SL7pwGfe7SiimxcD/LOuPCV6xM=",
+        "owner": "haskell",
+        "repo": "cabal",
+        "rev": "5ff598c67f53f7c4f48e31d722ba37172230c462",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "3.4",
+        "repo": "cabal",
+        "type": "github"
+      }
+    },
+    "cabal-34_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1645834128,
+        "narHash": "sha256-wG3d+dOt14z8+ydz4SL7pwGfe7SiimxcD/LOuPCV6xM=",
+        "owner": "haskell",
+        "repo": "cabal",
+        "rev": "5ff598c67f53f7c4f48e31d722ba37172230c462",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "3.4",
+        "repo": "cabal",
+        "type": "github"
+      }
+    },
+    "cabal-36": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1669081697,
+        "narHash": "sha256-I5or+V7LZvMxfbYgZATU4awzkicBwwok4mVoje+sGmU=",
+        "owner": "haskell",
+        "repo": "cabal",
+        "rev": "8fd619e33d34924a94e691c5fea2c42f0fc7f144",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "3.6",
+        "repo": "cabal",
+        "type": "github"
+      }
+    },
+    "cabal-36_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1669081697,
+        "narHash": "sha256-I5or+V7LZvMxfbYgZATU4awzkicBwwok4mVoje+sGmU=",
+        "owner": "haskell",
+        "repo": "cabal",
+        "rev": "8fd619e33d34924a94e691c5fea2c42f0fc7f144",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "3.6",
+        "repo": "cabal",
+        "type": "github"
+      }
+    },
     "cabal-head": {
       "flake": false,
       "locked": {
@@ -13,6 +235,72 @@
       "original": {
         "owner": "haskell",
         "repo": "cabal",
+        "type": "github"
+      }
+    },
+    "cardano-shell": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1608537748,
+        "narHash": "sha256-PulY1GfiMgKVnBci3ex4ptk2UNYMXqGjJOxcPy2KYT4=",
+        "owner": "input-output-hk",
+        "repo": "cardano-shell",
+        "rev": "9392c75087cb9a3d453998f4230930dea3a95725",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "cardano-shell",
+        "type": "github"
+      }
+    },
+    "cardano-shell_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1608537748,
+        "narHash": "sha256-PulY1GfiMgKVnBci3ex4ptk2UNYMXqGjJOxcPy2KYT4=",
+        "owner": "input-output-hk",
+        "repo": "cardano-shell",
+        "rev": "9392c75087cb9a3d453998f4230930dea3a95725",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "cardano-shell",
+        "type": "github"
+      }
+    },
+    "cpp-httplib": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1595279716,
+        "narHash": "sha256-cZW/iEwlaB4UQ0OQLNqboY9addncIM/OsxxPzqmATmE=",
+        "owner": "yhirose",
+        "repo": "cpp-httplib",
+        "rev": "72ce293fed9f9335e92c95ab7d085feed18c0ee8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "yhirose",
+        "repo": "cpp-httplib",
+        "rev": "72ce293fed9f9335e92c95ab7d085feed18c0ee8",
+        "type": "github"
+      }
+    },
+    "cryptopp": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1632484127,
+        "narHash": "sha256-a3TYaK34WvKEXN7LKAfGwQ3ZL6a3k/zMZyyVfnkQqO4=",
+        "owner": "weidai11",
+        "repo": "cryptopp",
+        "rev": "69bf6b53052b59ccb57ce068ce741988ae087317",
+        "type": "github"
+      },
+      "original": {
+        "owner": "weidai11",
+        "repo": "cryptopp",
+        "rev": "69bf6b53052b59ccb57ce068ce741988ae087317",
         "type": "github"
       }
     },
@@ -53,6 +341,23 @@
         "type": "github"
       }
     },
+    "ethereum-legacytests": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1633533576,
+        "narHash": "sha256-43lkAi6Z492pbHV+jySYXzvNtoGEGsndnBkxfYgmqFM=",
+        "owner": "ethereum",
+        "repo": "legacytests",
+        "rev": "d7abc42a7b352a7b44b1f66b58aca54e4af6a9d7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ethereum",
+        "repo": "legacytests",
+        "rev": "d7abc42a7b352a7b44b1f66b58aca54e4af6a9d7",
+        "type": "github"
+      }
+    },
     "ethereum-tests": {
       "flake": false,
       "locked": {
@@ -67,6 +372,23 @@
         "owner": "ethereum",
         "ref": "v12.2",
         "repo": "tests",
+        "type": "github"
+      }
+    },
+    "ethereum-tests_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1637090666,
+        "narHash": "sha256-B3fMpp/dpnwtCQzxI45kptJVwIM/kMo9hptcMP2B5n0=",
+        "owner": "ethereum",
+        "repo": "tests",
+        "rev": "6401889dec4eee58e808fd178fb2c7f628a3e039",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ethereum",
+        "repo": "tests",
+        "rev": "6401889dec4eee58e808fd178fb2c7f628a3e039",
         "type": "github"
       }
     },
@@ -102,6 +424,104 @@
         "type": "github"
       }
     },
+    "flake-compat_3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1673956053,
+        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_4": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1673956053,
+        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_5": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1672831974,
+        "narHash": "sha256-z9k3MfslLjWQfnjBtEtJZdq3H7kyi2kQtUThfTgdRk0=",
+        "owner": "input-output-hk",
+        "repo": "flake-compat",
+        "rev": "45f2638735f8cdc40fe302742b79f248d23eb368",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "ref": "hkm/gitlab-fix",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_6": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1673956053,
+        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_7": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1673956053,
+        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_8": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1672831974,
+        "narHash": "sha256-z9k3MfslLjWQfnjBtEtJZdq3H7kyi2kQtUThfTgdRk0=",
+        "owner": "input-output-hk",
+        "repo": "flake-compat",
+        "rev": "45f2638735f8cdc40fe302742b79f248d23eb368",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "ref": "hkm/gitlab-fix",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -112,6 +532,21 @@
         "owner": "numtide",
         "repo": "flake-utils",
         "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_10": {
+      "locked": {
+        "lastModified": 1678901627,
+        "narHash": "sha256-U02riOqrKKzwjsxc/400XnElV+UtPUQWpANPlyazjH0=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "93a2b84fc4b70d9e089d029deacc3583435c2ed6",
         "type": "github"
       },
       "original": {
@@ -186,6 +621,88 @@
         "type": "github"
       }
     },
+    "flake-utils_6": {
+      "locked": {
+        "lastModified": 1644229661,
+        "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_7": {
+      "locked": {
+        "lastModified": 1679360468,
+        "narHash": "sha256-LGnza3cfXF10Biw3ZTg0u9o9t7s680Ww200t5KkHTh8=",
+        "owner": "hamishmack",
+        "repo": "flake-utils",
+        "rev": "e1ea268ff47ad475443dbabcd54744b4e5b9d4f5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hamishmack",
+        "ref": "hkm/nested-hydraJobs",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_8": {
+      "inputs": {
+        "systems": "systems_4"
+      },
+      "locked": {
+        "lastModified": 1689068808,
+        "narHash": "sha256-6ixXo3wt24N/melDWjq70UuHQLxGV8jZvooRanIHXw0=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "919d646de7be200f3bf08cb76ae1f09402b6f9b4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_9": {
+      "locked": {
+        "lastModified": 1679360468,
+        "narHash": "sha256-LGnza3cfXF10Biw3ZTg0u9o9t7s680Ww200t5KkHTh8=",
+        "owner": "hamishmack",
+        "repo": "flake-utils",
+        "rev": "e1ea268ff47ad475443dbabcd54744b4e5b9d4f5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hamishmack",
+        "ref": "hkm/nested-hydraJobs",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "fmt-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1661615830,
+        "narHash": "sha256-rP6ymyRc7LnKxUXwPpzhHOQvpJkpnRFOt2ctvUNlYI0=",
+        "owner": "fmtlib",
+        "repo": "fmt",
+        "rev": "a33701196adfad74917046096bf5a2aa0ab0bb50",
+        "type": "github"
+      },
+      "original": {
+        "owner": "fmtlib",
+        "ref": "9.1.0",
+        "repo": "fmt",
+        "type": "github"
+      }
+    },
     "foundry": {
       "inputs": {
         "flake-utils": "flake-utils_3",
@@ -226,19 +743,257 @@
         "type": "github"
       }
     },
+    "foundry_3": {
+      "inputs": {
+        "flake-utils": "flake-utils_6",
+        "nixpkgs": "nixpkgs_5"
+      },
+      "locked": {
+        "lastModified": 1688462028,
+        "narHash": "sha256-+43L9rwbNC1cO0LrinxjaolmyIH/STpL67uf2s6+6C0=",
+        "owner": "shazow",
+        "repo": "foundry.nix",
+        "rev": "e8fb5553c880942ac5215fb210ada54841605c62",
+        "type": "github"
+      },
+      "original": {
+        "owner": "shazow",
+        "ref": "monthly",
+        "repo": "foundry.nix",
+        "type": "github"
+      }
+    },
+    "ghc-8.6.5-iohk": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1600920045,
+        "narHash": "sha256-DO6kxJz248djebZLpSzTGD6s8WRpNI9BTwUeOf5RwY8=",
+        "owner": "input-output-hk",
+        "repo": "ghc",
+        "rev": "95713a6ecce4551240da7c96b6176f980af75cae",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "ref": "release/8.6.5-iohk",
+        "repo": "ghc",
+        "type": "github"
+      }
+    },
+    "ghc-8.6.5-iohk_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1600920045,
+        "narHash": "sha256-DO6kxJz248djebZLpSzTGD6s8WRpNI9BTwUeOf5RwY8=",
+        "owner": "input-output-hk",
+        "repo": "ghc",
+        "rev": "95713a6ecce4551240da7c96b6176f980af75cae",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "ref": "release/8.6.5-iohk",
+        "repo": "ghc",
+        "type": "github"
+      }
+    },
+    "hackage": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1687998569,
+        "narHash": "sha256-VfTZVu2JV5z8KgPV++JAwn51gug02PDnTSnVrmt2YL8=",
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "rev": "2ef1dc1b2cac3fec82df01d8ee3fb3dd0a33815a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "type": "github"
+      }
+    },
+    "hackage_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1687998569,
+        "narHash": "sha256-VfTZVu2JV5z8KgPV++JAwn51gug02PDnTSnVrmt2YL8=",
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "rev": "2ef1dc1b2cac3fec82df01d8ee3fb3dd0a33815a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "type": "github"
+      }
+    },
     "halmos-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1690676552,
-        "narHash": "sha256-KB+Sm8ZdM0pnFpRSA4LOkuEGfk/o3tJq37q/FxAssqw=",
+        "lastModified": 1690945486,
+        "narHash": "sha256-zWbwWSWo3zldAfEGcHlDb/grnVmp+fKnltksUr0DK9M=",
         "owner": "a16z",
         "repo": "halmos",
-        "rev": "48e780069caa45b681db1f75b9d9cc4c4f005c44",
+        "rev": "2444e34c910b859c4fa57057a0fd7977cc7b150a",
         "type": "github"
       },
       "original": {
         "owner": "a16z",
         "repo": "halmos",
+        "type": "github"
+      }
+    },
+    "haskell-backend": {
+      "inputs": {
+        "flake-compat": "flake-compat_4",
+        "haskell-nix": "haskell-nix",
+        "nixpkgs": [
+          "kevm",
+          "k-framework",
+          "booster-backend",
+          "haskell-backend",
+          "haskell-nix",
+          "nixpkgs-unstable"
+        ],
+        "z3-src": "z3-src"
+      },
+      "locked": {
+        "lastModified": 1689600556,
+        "narHash": "sha256-/gk6l4UD9vvgaXZjqfVrRQOTAkabQGf7YFc3hTqbaMU=",
+        "owner": "runtimeverification",
+        "repo": "haskell-backend",
+        "rev": "3ac2c87da44ed9e8fe4ba4583fb5860a4680d821",
+        "type": "github"
+      },
+      "original": {
+        "owner": "runtimeverification",
+        "repo": "haskell-backend",
+        "rev": "3ac2c87da44ed9e8fe4ba4583fb5860a4680d821",
+        "type": "github"
+      }
+    },
+    "haskell-backend_2": {
+      "inputs": {
+        "flake-compat": "flake-compat_7",
+        "haskell-nix": "haskell-nix_2",
+        "nixpkgs": [
+          "kevm",
+          "k-framework",
+          "haskell-backend",
+          "haskell-nix",
+          "nixpkgs-unstable"
+        ],
+        "z3-src": "z3-src_2"
+      },
+      "locked": {
+        "lastModified": 1689600556,
+        "narHash": "sha256-/gk6l4UD9vvgaXZjqfVrRQOTAkabQGf7YFc3hTqbaMU=",
+        "owner": "runtimeverification",
+        "repo": "haskell-backend",
+        "rev": "3ac2c87da44ed9e8fe4ba4583fb5860a4680d821",
+        "type": "github"
+      },
+      "original": {
+        "owner": "runtimeverification",
+        "repo": "haskell-backend",
+        "rev": "3ac2c87da44ed9e8fe4ba4583fb5860a4680d821",
+        "type": "github"
+      }
+    },
+    "haskell-nix": {
+      "inputs": {
+        "HTTP": "HTTP",
+        "cabal-32": "cabal-32",
+        "cabal-34": "cabal-34",
+        "cabal-36": "cabal-36",
+        "cardano-shell": "cardano-shell",
+        "flake-compat": "flake-compat_5",
+        "flake-utils": "flake-utils_7",
+        "ghc-8.6.5-iohk": "ghc-8.6.5-iohk",
+        "hackage": "hackage",
+        "hls-1.10": "hls-1.10",
+        "hls-2.0": "hls-2.0",
+        "hpc-coveralls": "hpc-coveralls",
+        "hydra": "hydra",
+        "iserv-proxy": "iserv-proxy",
+        "nixpkgs": [
+          "kevm",
+          "k-framework",
+          "booster-backend",
+          "haskell-backend",
+          "haskell-nix",
+          "nixpkgs-unstable"
+        ],
+        "nixpkgs-2003": "nixpkgs-2003",
+        "nixpkgs-2105": "nixpkgs-2105",
+        "nixpkgs-2111": "nixpkgs-2111",
+        "nixpkgs-2205": "nixpkgs-2205",
+        "nixpkgs-2211": "nixpkgs-2211",
+        "nixpkgs-2305": "nixpkgs-2305",
+        "nixpkgs-unstable": "nixpkgs-unstable",
+        "old-ghc-nix": "old-ghc-nix",
+        "stackage": "stackage"
+      },
+      "locked": {
+        "lastModified": 1687999883,
+        "narHash": "sha256-4PxsyJekURUD/cZ7q0OAxfA6ZOoiton+6G1vgo9u+98=",
+        "owner": "input-output-hk",
+        "repo": "haskell.nix",
+        "rev": "b113a4a63c54f34d49d9f5d48ba6bbd65300bfa3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "haskell.nix",
+        "type": "github"
+      }
+    },
+    "haskell-nix_2": {
+      "inputs": {
+        "HTTP": "HTTP_2",
+        "cabal-32": "cabal-32_2",
+        "cabal-34": "cabal-34_2",
+        "cabal-36": "cabal-36_2",
+        "cardano-shell": "cardano-shell_2",
+        "flake-compat": "flake-compat_8",
+        "flake-utils": "flake-utils_9",
+        "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_2",
+        "hackage": "hackage_2",
+        "hls-1.10": "hls-1.10_2",
+        "hls-2.0": "hls-2.0_2",
+        "hpc-coveralls": "hpc-coveralls_2",
+        "hydra": "hydra_2",
+        "iserv-proxy": "iserv-proxy_2",
+        "nixpkgs": [
+          "kevm",
+          "k-framework",
+          "haskell-backend",
+          "haskell-nix",
+          "nixpkgs-unstable"
+        ],
+        "nixpkgs-2003": "nixpkgs-2003_2",
+        "nixpkgs-2105": "nixpkgs-2105_2",
+        "nixpkgs-2111": "nixpkgs-2111_2",
+        "nixpkgs-2205": "nixpkgs-2205_2",
+        "nixpkgs-2211": "nixpkgs-2211_2",
+        "nixpkgs-2305": "nixpkgs-2305_2",
+        "nixpkgs-unstable": "nixpkgs-unstable_2",
+        "old-ghc-nix": "old-ghc-nix_2",
+        "stackage": "stackage_2"
+      },
+      "locked": {
+        "lastModified": 1687999883,
+        "narHash": "sha256-4PxsyJekURUD/cZ7q0OAxfA6ZOoiton+6G1vgo9u+98=",
+        "owner": "input-output-hk",
+        "repo": "haskell.nix",
+        "rev": "b113a4a63c54f34d49d9f5d48ba6bbd65300bfa3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "haskell.nix",
         "type": "github"
       }
     },
@@ -253,16 +1008,426 @@
         "solidity": "solidity"
       },
       "locked": {
-        "lastModified": 1690823940,
-        "narHash": "sha256-ZT0oGINdw8oP6EKeL0BvnoMv4HcZZXbw0dTehy3vU1I=",
+        "lastModified": 1690973827,
+        "narHash": "sha256-CSd2L88Tsy1SCeG6JnbQGfpnmsZeRkuPo92Qc2a7OX4=",
         "owner": "ethereum",
         "repo": "hevm",
-        "rev": "135fdd711c8410e4be15083c7e02aa24cec83c63",
+        "rev": "855530db4a2dc78189f74c6aef2d267ee9a4335e",
         "type": "github"
       },
       "original": {
         "owner": "ethereum",
         "repo": "hevm",
+        "type": "github"
+      }
+    },
+    "hls-1.10": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1680000865,
+        "narHash": "sha256-rc7iiUAcrHxwRM/s0ErEsSPxOR3u8t7DvFeWlMycWgo=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "b08691db779f7a35ff322b71e72a12f6e3376fd9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "1.10.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-1.10_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1680000865,
+        "narHash": "sha256-rc7iiUAcrHxwRM/s0ErEsSPxOR3u8t7DvFeWlMycWgo=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "b08691db779f7a35ff322b71e72a12f6e3376fd9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "1.10.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.0": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1684398654,
+        "narHash": "sha256-RW44up2BIyBBYN6tZur5f9kDDR3kr0Rd+TgPbLTfwB4=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "20c6d1e731cd9c0beef7338e2fc7a8126ba9b6fb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.0.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.0_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1684398654,
+        "narHash": "sha256-RW44up2BIyBBYN6tZur5f9kDDR3kr0Rd+TgPbLTfwB4=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "20c6d1e731cd9c0beef7338e2fc7a8126ba9b6fb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.0.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hpc-coveralls": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1607498076,
+        "narHash": "sha256-8uqsEtivphgZWYeUo5RDUhp6bO9j2vaaProQxHBltQk=",
+        "owner": "sevanspowell",
+        "repo": "hpc-coveralls",
+        "rev": "14df0f7d229f4cd2e79f8eabb1a740097fdfa430",
+        "type": "github"
+      },
+      "original": {
+        "owner": "sevanspowell",
+        "repo": "hpc-coveralls",
+        "type": "github"
+      }
+    },
+    "hpc-coveralls_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1607498076,
+        "narHash": "sha256-8uqsEtivphgZWYeUo5RDUhp6bO9j2vaaProQxHBltQk=",
+        "owner": "sevanspowell",
+        "repo": "hpc-coveralls",
+        "rev": "14df0f7d229f4cd2e79f8eabb1a740097fdfa430",
+        "type": "github"
+      },
+      "original": {
+        "owner": "sevanspowell",
+        "repo": "hpc-coveralls",
+        "type": "github"
+      }
+    },
+    "hydra": {
+      "inputs": {
+        "nix": "nix",
+        "nixpkgs": [
+          "kevm",
+          "k-framework",
+          "booster-backend",
+          "haskell-backend",
+          "haskell-nix",
+          "hydra",
+          "nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1671755331,
+        "narHash": "sha256-hXsgJj0Cy0ZiCiYdW2OdBz5WmFyOMKuw4zyxKpgUKm4=",
+        "owner": "NixOS",
+        "repo": "hydra",
+        "rev": "f48f00ee6d5727ae3e488cbf9ce157460853fea8",
+        "type": "github"
+      },
+      "original": {
+        "id": "hydra",
+        "type": "indirect"
+      }
+    },
+    "hydra_2": {
+      "inputs": {
+        "nix": "nix_2",
+        "nixpkgs": [
+          "kevm",
+          "k-framework",
+          "haskell-backend",
+          "haskell-nix",
+          "hydra",
+          "nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1671755331,
+        "narHash": "sha256-hXsgJj0Cy0ZiCiYdW2OdBz5WmFyOMKuw4zyxKpgUKm4=",
+        "owner": "NixOS",
+        "repo": "hydra",
+        "rev": "f48f00ee6d5727ae3e488cbf9ce157460853fea8",
+        "type": "github"
+      },
+      "original": {
+        "id": "hydra",
+        "type": "indirect"
+      }
+    },
+    "immer-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1634324349,
+        "narHash": "sha256-1OicqmyM3Rcrs/jkRMip2pXITQnVDRrHbQbEpZZ4nnU=",
+        "owner": "runtimeverification",
+        "repo": "immer",
+        "rev": "198c2ae260d49ef1800a2fe4433e07d7dec20059",
+        "type": "github"
+      },
+      "original": {
+        "owner": "runtimeverification",
+        "repo": "immer",
+        "rev": "198c2ae260d49ef1800a2fe4433e07d7dec20059",
+        "type": "github"
+      }
+    },
+    "iserv-proxy": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1670983692,
+        "narHash": "sha256-avLo34JnI9HNyOuauK5R69usJm+GfW3MlyGlYxZhTgY=",
+        "ref": "hkm/remote-iserv",
+        "rev": "50d0abb3317ac439a4e7495b185a64af9b7b9300",
+        "revCount": 10,
+        "type": "git",
+        "url": "https://gitlab.haskell.org/hamishmack/iserv-proxy.git"
+      },
+      "original": {
+        "ref": "hkm/remote-iserv",
+        "type": "git",
+        "url": "https://gitlab.haskell.org/hamishmack/iserv-proxy.git"
+      }
+    },
+    "iserv-proxy_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1670983692,
+        "narHash": "sha256-avLo34JnI9HNyOuauK5R69usJm+GfW3MlyGlYxZhTgY=",
+        "ref": "hkm/remote-iserv",
+        "rev": "50d0abb3317ac439a4e7495b185a64af9b7b9300",
+        "revCount": 10,
+        "type": "git",
+        "url": "https://gitlab.haskell.org/hamishmack/iserv-proxy.git"
+      },
+      "original": {
+        "ref": "hkm/remote-iserv",
+        "type": "git",
+        "url": "https://gitlab.haskell.org/hamishmack/iserv-proxy.git"
+      }
+    },
+    "k-framework": {
+      "inputs": {
+        "booster-backend": "booster-backend",
+        "flake-compat": "flake-compat_6",
+        "flake-utils": "flake-utils_8",
+        "haskell-backend": "haskell-backend_2",
+        "llvm-backend": "llvm-backend",
+        "mavenix": "mavenix_2",
+        "nixpkgs": [
+          "kevm",
+          "nixpkgs"
+        ],
+        "rv-utils": "rv-utils"
+      },
+      "locked": {
+        "lastModified": 1689845067,
+        "narHash": "sha256-twtXBTHdGow6k9W02k/mD7jBlSYXfOd4jLO6DLOhZY8=",
+        "owner": "runtimeverification",
+        "repo": "k",
+        "rev": "14637490829833d7b5871b372fb72fb097116e92",
+        "type": "github"
+      },
+      "original": {
+        "owner": "runtimeverification",
+        "ref": "v6.0.27",
+        "repo": "k",
+        "type": "github"
+      }
+    },
+    "kevm": {
+      "inputs": {
+        "blockchain-k-plugin": "blockchain-k-plugin",
+        "ethereum-legacytests": "ethereum-legacytests",
+        "ethereum-tests": "ethereum-tests_2",
+        "flake-utils": [
+          "kevm",
+          "k-framework",
+          "flake-utils"
+        ],
+        "foundry": "foundry_3",
+        "haskell-backend": [
+          "kevm",
+          "k-framework",
+          "haskell-backend"
+        ],
+        "k-framework": "k-framework",
+        "nixpkgs": "nixpkgs_10",
+        "poetry2nix": [
+          "kevm",
+          "pyk",
+          "poetry2nix"
+        ],
+        "pyk": "pyk",
+        "rv-utils": "rv-utils_2"
+      },
+      "locked": {
+        "lastModified": 1690929479,
+        "narHash": "sha256-m84Xf5R4WCfiuYf4Mjq+cMUoVJUs2W56WeJYsCiaU7Y=",
+        "owner": "runtimeverification",
+        "repo": "evm-semantics",
+        "rev": "afca544b85a973889dcd7d1f5dbfed6a75d62bcc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "runtimeverification",
+        "repo": "evm-semantics",
+        "type": "github"
+      }
+    },
+    "libff": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1588032522,
+        "narHash": "sha256-I0kH2XLvHDSrdL/o4i6XozWQJV0UDv9zH6+sWS0UQHg=",
+        "owner": "scipr-lab",
+        "repo": "libff",
+        "rev": "5835b8c59d4029249645cf551f417608c48f2770",
+        "type": "github"
+      },
+      "original": {
+        "owner": "scipr-lab",
+        "repo": "libff",
+        "rev": "5835b8c59d4029249645cf551f417608c48f2770",
+        "type": "github"
+      }
+    },
+    "llvm-backend": {
+      "inputs": {
+        "fmt-src": "fmt-src",
+        "immer-src": "immer-src",
+        "mavenix": "mavenix",
+        "nixpkgs": [
+          "kevm",
+          "k-framework",
+          "haskell-backend",
+          "nixpkgs"
+        ],
+        "pybind11-src": "pybind11-src",
+        "rapidjson-src": "rapidjson-src",
+        "utils": "utils_2"
+      },
+      "locked": {
+        "lastModified": 1689842576,
+        "narHash": "sha256-8CwpP7YXx021KK/cbEzwnUzOuO+uzUCL4dLrWOpfduE=",
+        "owner": "runtimeverification",
+        "repo": "llvm-backend",
+        "rev": "b1f1e9c41322a7e3303eb8b973f379f82462d05c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "runtimeverification",
+        "repo": "llvm-backend",
+        "type": "github"
+      }
+    },
+    "lowdown-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1633514407,
+        "narHash": "sha256-Dw32tiMjdK9t3ETl5fzGrutQTzh2rufgZV4A/BbxuD4=",
+        "owner": "kristapsdz",
+        "repo": "lowdown",
+        "rev": "d2c2b44ff6c27b936ec27358a2653caaef8f73b8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "kristapsdz",
+        "repo": "lowdown",
+        "type": "github"
+      }
+    },
+    "lowdown-src_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1633514407,
+        "narHash": "sha256-Dw32tiMjdK9t3ETl5fzGrutQTzh2rufgZV4A/BbxuD4=",
+        "owner": "kristapsdz",
+        "repo": "lowdown",
+        "rev": "d2c2b44ff6c27b936ec27358a2653caaef8f73b8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "kristapsdz",
+        "repo": "lowdown",
+        "type": "github"
+      }
+    },
+    "mavenix": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_8",
+        "utils": "utils"
+      },
+      "locked": {
+        "lastModified": 1643802645,
+        "narHash": "sha256-BynM25iwp/l3FyrcHqiNJdDxvN6IxSM3/zkFR6PD3B0=",
+        "owner": "nix-community",
+        "repo": "mavenix",
+        "rev": "ce9ddfd7f361190e8e8dcfaf6b8282eebbb3c7cb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "mavenix",
+        "type": "github"
+      }
+    },
+    "mavenix_2": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_9",
+        "utils": "utils_3"
+      },
+      "locked": {
+        "lastModified": 1689018333,
+        "narHash": "sha256-sthxx50rj0E7gv38oeMj8GZOp7i1776P1qZsM7pVLd0=",
+        "owner": "goodlyrottenapple",
+        "repo": "mavenix",
+        "rev": "153d69e62f87e5dd37d35492cc3e35dd80d2b5fa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "goodlyrottenapple",
+        "repo": "mavenix",
+        "type": "github"
+      }
+    },
+    "nix": {
+      "inputs": {
+        "lowdown-src": "lowdown-src",
+        "nixpkgs": "nixpkgs_6",
+        "nixpkgs-regression": "nixpkgs-regression"
+      },
+      "locked": {
+        "lastModified": 1661606874,
+        "narHash": "sha256-9+rpYzI+SmxJn+EbYxjGv68Ucp22bdFUSy/4LkHkkDQ=",
+        "owner": "NixOS",
+        "repo": "nix",
+        "rev": "11e45768b34fdafdcf019ddbd337afa16127ff0f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "2.11.0",
+        "repo": "nix",
         "type": "github"
       }
     },
@@ -282,6 +1447,27 @@
         "type": "github"
       }
     },
+    "nix_2": {
+      "inputs": {
+        "lowdown-src": "lowdown-src_2",
+        "nixpkgs": "nixpkgs_7",
+        "nixpkgs-regression": "nixpkgs-regression_2"
+      },
+      "locked": {
+        "lastModified": 1661606874,
+        "narHash": "sha256-9+rpYzI+SmxJn+EbYxjGv68Ucp22bdFUSy/4LkHkkDQ=",
+        "owner": "NixOS",
+        "repo": "nix",
+        "rev": "11e45768b34fdafdcf019ddbd337afa16127ff0f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "2.11.0",
+        "repo": "nix",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1681205926,
@@ -293,6 +1479,293 @@
       },
       "original": {
         "owner": "NixOS",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2003": {
+      "locked": {
+        "lastModified": 1620055814,
+        "narHash": "sha256-8LEHoYSJiL901bTMVatq+rf8y7QtWuZhwwpKE2fyaRY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1db42b7fe3878f3f5f7a4f2dc210772fd080e205",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-20.03-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2003_2": {
+      "locked": {
+        "lastModified": 1620055814,
+        "narHash": "sha256-8LEHoYSJiL901bTMVatq+rf8y7QtWuZhwwpKE2fyaRY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1db42b7fe3878f3f5f7a4f2dc210772fd080e205",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-20.03-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2105": {
+      "locked": {
+        "lastModified": 1659914493,
+        "narHash": "sha256-lkA5X3VNMKirvA+SUzvEhfA7XquWLci+CGi505YFAIs=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "022caabb5f2265ad4006c1fa5b1ebe69fb0c3faf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-21.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2105_2": {
+      "locked": {
+        "lastModified": 1659914493,
+        "narHash": "sha256-lkA5X3VNMKirvA+SUzvEhfA7XquWLci+CGi505YFAIs=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "022caabb5f2265ad4006c1fa5b1ebe69fb0c3faf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-21.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2111": {
+      "locked": {
+        "lastModified": 1659446231,
+        "narHash": "sha256-hekabNdTdgR/iLsgce5TGWmfIDZ86qjPhxDg/8TlzhE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "eabc38219184cc3e04a974fe31857d8e0eac098d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-21.11-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2111_2": {
+      "locked": {
+        "lastModified": 1659446231,
+        "narHash": "sha256-hekabNdTdgR/iLsgce5TGWmfIDZ86qjPhxDg/8TlzhE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "eabc38219184cc3e04a974fe31857d8e0eac098d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-21.11-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2205": {
+      "locked": {
+        "lastModified": 1682600000,
+        "narHash": "sha256-ha4BehR1dh8EnXSoE1m/wyyYVvHI9txjW4w5/oxsW5Y=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "50fc86b75d2744e1ab3837ef74b53f103a9b55a0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-22.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2205_2": {
+      "locked": {
+        "lastModified": 1682600000,
+        "narHash": "sha256-ha4BehR1dh8EnXSoE1m/wyyYVvHI9txjW4w5/oxsW5Y=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "50fc86b75d2744e1ab3837ef74b53f103a9b55a0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-22.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2211": {
+      "locked": {
+        "lastModified": 1685314633,
+        "narHash": "sha256-8LXBPqTQXl5ofkjpJ18JcbmLJ/lWDoMxtUwiDYv0wro=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "c8a17ce7abc03c50cd072e9e6c9b389c5f61836b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-22.11-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2211_2": {
+      "locked": {
+        "lastModified": 1685314633,
+        "narHash": "sha256-8LXBPqTQXl5ofkjpJ18JcbmLJ/lWDoMxtUwiDYv0wro=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "c8a17ce7abc03c50cd072e9e6c9b389c5f61836b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-22.11-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2305": {
+      "locked": {
+        "lastModified": 1685338297,
+        "narHash": "sha256-+Aq4O0Jn1W1q927ZHc3Zn6RO7bwQGmb6O8xYoGy0KrM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "6287b47dbfabbb8bfbb9b1b53d198ad58a774de4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-23.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2305_2": {
+      "locked": {
+        "lastModified": 1685338297,
+        "narHash": "sha256-+Aq4O0Jn1W1q927ZHc3Zn6RO7bwQGmb6O8xYoGy0KrM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "6287b47dbfabbb8bfbb9b1b53d198ad58a774de4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-23.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-regression": {
+      "locked": {
+        "lastModified": 1643052045,
+        "narHash": "sha256-uGJ0VXIhWKGXxkeNnq4TvV3CIOkUJ3PAoLZ3HMzNVMw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "type": "github"
+      }
+    },
+    "nixpkgs-regression_2": {
+      "locked": {
+        "lastModified": 1643052045,
+        "narHash": "sha256-uGJ0VXIhWKGXxkeNnq4TvV3CIOkUJ3PAoLZ3HMzNVMw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "type": "github"
+      }
+    },
+    "nixpkgs-unstable": {
+      "locked": {
+        "lastModified": 1685347552,
+        "narHash": "sha256-9woSppRyUFo26yUffORTzttJ+apOt8MmCv6RxpPNTU4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "f2f1ec390714d303cf84ba086e34e45b450dd8c4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-unstable_2": {
+      "locked": {
+        "lastModified": 1685347552,
+        "narHash": "sha256-9woSppRyUFo26yUffORTzttJ+apOt8MmCv6RxpPNTU4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "f2f1ec390714d303cf84ba086e34e45b450dd8c4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_10": {
+      "locked": {
+        "lastModified": 1680577567,
+        "narHash": "sha256-Y4W57i0TzczqwMTjfVSbAZT5RJx7u+mpQIW/ofrkTQs=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b01f185e4866de7c5b5a82f833ca9ea3c3f72fc4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b01f185e4866de7c5b5a82f833ca9ea3c3f72fc4",
+        "type": "github"
+      }
+    },
+    "nixpkgs_11": {
+      "locked": {
+        "lastModified": 1690977828,
+        "narHash": "sha256-alzisk8wOpZesdWbHaQur/p5QsNdWBiWr0/k+b42ySE=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "e0390ce209a966d5c01ee220755db804a35f8f78",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -343,16 +1816,196 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1690899495,
-        "narHash": "sha256-W6Znk/udyFvBOWtY2VPAeRHjVzH0C4mnXf8O1t55Olo=",
-        "owner": "nixos",
+        "lastModified": 1666753130,
+        "narHash": "sha256-Wff1dGPFSneXJLI2c0kkdWTgxnQ416KE6X4KnFkgPYQ=",
+        "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7965b589f303dfe01e6128eb0b52654cc444715d",
+        "rev": "f540aeda6f677354f1e7144ab04352f61aaa0118",
         "type": "github"
       },
       "original": {
-        "owner": "nixos",
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_6": {
+      "locked": {
+        "lastModified": 1657693803,
+        "narHash": "sha256-G++2CJ9u0E7NNTAi9n5G8TdDmGJXcIjkJ3NF8cetQB8=",
+        "owner": "NixOS",
         "repo": "nixpkgs",
+        "rev": "365e1b3a859281cf11b94f87231adeabbdd878a2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-22.05-small",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_7": {
+      "locked": {
+        "lastModified": 1657693803,
+        "narHash": "sha256-G++2CJ9u0E7NNTAi9n5G8TdDmGJXcIjkJ3NF8cetQB8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "365e1b3a859281cf11b94f87231adeabbdd878a2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-22.05-small",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_8": {
+      "locked": {
+        "lastModified": 1621552131,
+        "narHash": "sha256-AD/AEXv+QOYAg0PIqMYv2nbGOGTIwfOGKtz3rE+y+Tc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d42cd445dde587e9a993cd9434cb43da07c4c5de",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_9": {
+      "locked": {
+        "lastModified": 1621552131,
+        "narHash": "sha256-AD/AEXv+QOYAg0PIqMYv2nbGOGTIwfOGKtz3rE+y+Tc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d42cd445dde587e9a993cd9434cb43da07c4c5de",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "old-ghc-nix": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1631092763,
+        "narHash": "sha256-sIKgO+z7tj4lw3u6oBZxqIhDrzSkvpHtv0Kki+lh9Fg=",
+        "owner": "angerman",
+        "repo": "old-ghc-nix",
+        "rev": "af48a7a7353e418119b6dfe3cd1463a657f342b8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "angerman",
+        "ref": "master",
+        "repo": "old-ghc-nix",
+        "type": "github"
+      }
+    },
+    "old-ghc-nix_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1631092763,
+        "narHash": "sha256-sIKgO+z7tj4lw3u6oBZxqIhDrzSkvpHtv0Kki+lh9Fg=",
+        "owner": "angerman",
+        "repo": "old-ghc-nix",
+        "rev": "af48a7a7353e418119b6dfe3cd1463a657f342b8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "angerman",
+        "ref": "master",
+        "repo": "old-ghc-nix",
+        "type": "github"
+      }
+    },
+    "poetry2nix": {
+      "inputs": {
+        "flake-utils": "flake-utils_10",
+        "nixpkgs": [
+          "kevm",
+          "pyk",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1680067032,
+        "narHash": "sha256-RF07f1iZkJOdSbv+1myXdvgCxUsUjHdHBF7CEX3rnag=",
+        "owner": "nix-community",
+        "repo": "poetry2nix",
+        "rev": "39c356df8277758138829c7b3694e58fe8d4afa2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "ref": "master",
+        "repo": "poetry2nix",
+        "type": "github"
+      }
+    },
+    "pybind11-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1657936673,
+        "narHash": "sha256-/X8DZPFsNrKGbhjZ1GFOj17/NU6p4R+saCW3pLKVNeA=",
+        "owner": "pybind",
+        "repo": "pybind11",
+        "rev": "0ba639d6177659c5dc2955ac06ad7b5b0d22e05c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pybind",
+        "repo": "pybind11",
+        "rev": "0ba639d6177659c5dc2955ac06ad7b5b0d22e05c",
+        "type": "github"
+      }
+    },
+    "pyk": {
+      "inputs": {
+        "flake-utils": [
+          "kevm",
+          "k-framework",
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "kevm",
+          "k-framework",
+          "nixpkgs"
+        ],
+        "poetry2nix": "poetry2nix"
+      },
+      "locked": {
+        "lastModified": 1690230284,
+        "narHash": "sha256-2mWdSE3d5dMMM6ntcYVZZHYIU91WVrxLiyASV0FAtaA=",
+        "owner": "runtimeverification",
+        "repo": "pyk",
+        "rev": "dd38446e03ba1863bacb354a8a91b6b1146e49ec",
+        "type": "github"
+      },
+      "original": {
+        "owner": "runtimeverification",
+        "ref": "v0.1.378",
+        "repo": "pyk",
+        "type": "github"
+      }
+    },
+    "rapidjson-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1472111945,
+        "narHash": "sha256-SxUXSOQDZ0/3zlFI4R84J56/1fkw2jhge4mexNF6Pco=",
+        "owner": "Tencent",
+        "repo": "rapidjson",
+        "rev": "f54b0e47a08782a6131cc3d60f94d038fa6e0a51",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Tencent",
+        "repo": "rapidjson",
+        "rev": "f54b0e47a08782a6131cc3d60f94d038fa6e0a51",
         "type": "github"
       }
     },
@@ -364,7 +2017,55 @@
         "foundry": "foundry",
         "halmos-src": "halmos-src",
         "hevm": "hevm",
-        "nixpkgs": "nixpkgs_5"
+        "kevm": "kevm",
+        "nixpkgs": "nixpkgs_11"
+      }
+    },
+    "rv-utils": {
+      "locked": {
+        "lastModified": 1659349707,
+        "narHash": "sha256-+RwJvYwRS4In+pl8R5Uz+R/yZ5yO5SAa7X6UR+eSC2U=",
+        "owner": "runtimeverification",
+        "repo": "rv-nix-tools",
+        "rev": "7026604726c5247ceb6e7a1a7532302a58e7e2bf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "runtimeverification",
+        "repo": "rv-nix-tools",
+        "type": "github"
+      }
+    },
+    "rv-utils_2": {
+      "locked": {
+        "lastModified": 1659349707,
+        "narHash": "sha256-+RwJvYwRS4In+pl8R5Uz+R/yZ5yO5SAa7X6UR+eSC2U=",
+        "owner": "runtimeverification",
+        "repo": "rv-nix-tools",
+        "rev": "7026604726c5247ceb6e7a1a7532302a58e7e2bf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "runtimeverification",
+        "repo": "rv-nix-tools",
+        "type": "github"
+      }
+    },
+    "secp256k1": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1502408521,
+        "narHash": "sha256-PyqNZGER9VypH35S/aU4EBeepieI3BGXrYsJ141os24=",
+        "owner": "bitcoin-core",
+        "repo": "secp256k1",
+        "rev": "f532bdc9f77f7bbf7e93faabfbe9c483f0a9f75f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "bitcoin-core",
+        "repo": "secp256k1",
+        "rev": "f532bdc9f77f7bbf7e93faabfbe9c483f0a9f75f",
+        "type": "github"
       }
     },
     "solidity": {
@@ -381,6 +2082,38 @@
         "owner": "ethereum",
         "repo": "solidity",
         "rev": "1c8745c54a239d20b6fb0f79a8bd2628d779b27e",
+        "type": "github"
+      }
+    },
+    "stackage": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1687911052,
+        "narHash": "sha256-iWrKX6JfcN1+uUQimaFXzvLwj3tLMvWTwf0zqflCf1s=",
+        "owner": "input-output-hk",
+        "repo": "stackage.nix",
+        "rev": "8e758d849bd7cf8c423d9f9308a9c1b5f56c286c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "stackage.nix",
+        "type": "github"
+      }
+    },
+    "stackage_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1687911052,
+        "narHash": "sha256-iWrKX6JfcN1+uUQimaFXzvLwj3tLMvWTwf0zqflCf1s=",
+        "owner": "input-output-hk",
+        "repo": "stackage.nix",
+        "rev": "8e758d849bd7cf8c423d9f9308a9c1b5f56c286c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "stackage.nix",
         "type": "github"
       }
     },
@@ -426,6 +2159,117 @@
       "original": {
         "owner": "nix-systems",
         "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_4": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "utils": {
+      "locked": {
+        "lastModified": 1620759905,
+        "narHash": "sha256-WiyWawrgmyN0EdmiHyG2V+fqReiVi8bM9cRdMaKQOFg=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b543720b25df6ffdfcf9227afafc5b8c1fabfae8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "utils_2": {
+      "locked": {
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "utils_3": {
+      "locked": {
+        "lastModified": 1620759905,
+        "narHash": "sha256-WiyWawrgmyN0EdmiHyG2V+fqReiVi8bM9cRdMaKQOFg=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b543720b25df6ffdfcf9227afafc5b8c1fabfae8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "xbyak": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1518572786,
+        "narHash": "sha256-jqDSNDcqK7010ig941hrJFkv1X7MbgXmhPOOE9wHmho=",
+        "owner": "herumi",
+        "repo": "xbyak",
+        "rev": "f0a8f7faa27121f28186c2a7f4222a9fc66c283d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "herumi",
+        "repo": "xbyak",
+        "rev": "f0a8f7faa27121f28186c2a7f4222a9fc66c283d",
+        "type": "github"
+      }
+    },
+    "z3-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1674011426,
+        "narHash": "sha256-7cuUf29TMpX62PwO1ab3ZuzmzlcrRjTKB1CyXnYgYus=",
+        "owner": "Z3Prover",
+        "repo": "z3",
+        "rev": "3012293c35eadbfd73e5b94adbe50b0cc44ffb83",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Z3Prover",
+        "ref": "z3-4.12.1",
+        "repo": "z3",
+        "type": "github"
+      }
+    },
+    "z3-src_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1674011426,
+        "narHash": "sha256-7cuUf29TMpX62PwO1ab3ZuzmzlcrRjTKB1CyXnYgYus=",
+        "owner": "Z3Prover",
+        "repo": "z3",
+        "rev": "3012293c35eadbfd73e5b94adbe50b0cc44ffb83",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Z3Prover",
+        "ref": "z3-4.12.1",
+        "repo": "z3",
         "type": "github"
       }
     }

--- a/flake.lock
+++ b/flake.lock
@@ -709,11 +709,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1688462028,
-        "narHash": "sha256-+43L9rwbNC1cO0LrinxjaolmyIH/STpL67uf2s6+6C0=",
+        "lastModified": 1691140388,
+        "narHash": "sha256-AH3fx2VFGPRSOjnuakab4T4AdUstwTnFTbnkoU4df8Q=",
         "owner": "shazow",
         "repo": "foundry.nix",
-        "rev": "e8fb5553c880942ac5215fb210ada54841605c62",
+        "rev": "6089aad0ef615ac8c7b0c948d6052fa848c99523",
         "type": "github"
       },
       "original": {
@@ -832,11 +832,11 @@
     "halmos-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1690945486,
-        "narHash": "sha256-zWbwWSWo3zldAfEGcHlDb/grnVmp+fKnltksUr0DK9M=",
+        "lastModified": 1691101578,
+        "narHash": "sha256-TBG+TLU+Fh4eiKLtxe19aTcyfOQl/yPXxVbPYmVAVk8=",
         "owner": "a16z",
         "repo": "halmos",
-        "rev": "2444e34c910b859c4fa57057a0fd7977cc7b150a",
+        "rev": "fc61d2fb4f1470e03b9e46e4c435a842c6b7adb9",
         "type": "github"
       },
       "original": {
@@ -1008,15 +1008,16 @@
         "solidity": "solidity"
       },
       "locked": {
-        "lastModified": 1690973827,
-        "narHash": "sha256-CSd2L88Tsy1SCeG6JnbQGfpnmsZeRkuPo92Qc2a7OX4=",
+        "lastModified": 1691079668,
+        "narHash": "sha256-PuOu4twhml4LbzdWE50tQ+GmrKI2Gt6lKyfRHYaGRpc=",
         "owner": "ethereum",
         "repo": "hevm",
-        "rev": "855530db4a2dc78189f74c6aef2d267ee9a4335e",
+        "rev": "1a73dd3f0d03fb891eb1b82a1aaf3b95c6af58fd",
         "type": "github"
       },
       "original": {
         "owner": "ethereum",
+        "ref": "main",
         "repo": "hevm",
         "type": "github"
       }
@@ -1757,11 +1758,11 @@
     },
     "nixpkgs_11": {
       "locked": {
-        "lastModified": 1690977828,
-        "narHash": "sha256-alzisk8wOpZesdWbHaQur/p5QsNdWBiWr0/k+b42ySE=",
+        "lastModified": 1691147152,
+        "narHash": "sha256-WZ8wFSfQ2dg29FaHzYWYZpmvi9+a/lAZr5Gcj4rNXRA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e0390ce209a966d5c01ee220755db804a35f8f78",
+        "rev": "bf4d2e6c1ecdf5e46271bcb5f90541539e06446b",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -1,255 +1,34 @@
 {
   "nodes": {
-    "HTTP": {
+    "cabal-head": {
       "flake": false,
       "locked": {
-        "lastModified": 1451647621,
-        "narHash": "sha256-oHIyw3x0iKBexEo49YeUDV1k74ZtyYKGR2gNJXXRxts=",
-        "owner": "phadej",
-        "repo": "HTTP",
-        "rev": "9bc0996d412fef1787449d841277ef663ad9a915",
-        "type": "github"
-      },
-      "original": {
-        "owner": "phadej",
-        "repo": "HTTP",
-        "type": "github"
-      }
-    },
-    "ate-pairing": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1499347915,
-        "narHash": "sha256-IMfWgKkkX7UcUaOPtGRcYD8MdVEP5Z9JOOSJ4+P07G8=",
-        "owner": "herumi",
-        "repo": "ate-pairing",
-        "rev": "e69890125746cdaf25b5b51227d96678f76479fe",
-        "type": "github"
-      },
-      "original": {
-        "owner": "herumi",
-        "repo": "ate-pairing",
-        "rev": "e69890125746cdaf25b5b51227d96678f76479fe",
-        "type": "github"
-      }
-    },
-    "blank": {
-      "locked": {
-        "lastModified": 1625557891,
-        "narHash": "sha256-O8/MWsPBGhhyPoPLHZAuoZiiHo9q6FLlEeIDEXuj6T4=",
-        "owner": "divnix",
-        "repo": "blank",
-        "rev": "5a5d2684073d9f563072ed07c871d577a6c614a8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "divnix",
-        "repo": "blank",
-        "type": "github"
-      }
-    },
-    "blockchain-k-plugin": {
-      "inputs": {
-        "ate-pairing": "ate-pairing",
-        "cpp-httplib": "cpp-httplib",
-        "cryptopp": "cryptopp",
-        "flake-utils": [
-          "kevm",
-          "k-framework",
-          "flake-utils"
-        ],
-        "libff": "libff",
-        "nixpkgs": [
-          "kevm",
-          "k-framework",
-          "nixpkgs"
-        ],
-        "secp256k1": "secp256k1",
-        "xbyak": "xbyak"
-      },
-      "locked": {
-        "lastModified": 1679089255,
-        "narHash": "sha256-yXXgP+4tnbiz/hcsoGTsYM7o7jVZ6CVnG/KP650jBPE=",
-        "owner": "runtimeverification",
-        "repo": "blockchain-k-plugin",
-        "rev": "d9f5cf8f6caf16c04ac29aeaf0f77641f8203e1d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "runtimeverification",
-        "repo": "blockchain-k-plugin",
-        "rev": "d9f5cf8f6caf16c04ac29aeaf0f77641f8203e1d",
-        "type": "github"
-      }
-    },
-    "cabal-32": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1603716527,
-        "narHash": "sha256-X0TFfdD4KZpwl0Zr6x+PLxUt/VyKQfX7ylXHdmZIL+w=",
+        "lastModified": 1689711523,
+        "narHash": "sha256-lmECGcDNg+rgGAYTaK6v3xMiblrA+W0LOBDrWvaOr4Y=",
         "owner": "haskell",
         "repo": "cabal",
-        "rev": "48bf10787e27364730dd37a42b603cee8d6af7ee",
+        "rev": "baa767a90dd8c0d3bafd82b48ff8e83b779f238a",
         "type": "github"
       },
       "original": {
         "owner": "haskell",
-        "ref": "3.2",
         "repo": "cabal",
         "type": "github"
       }
     },
-    "cabal-34": {
+    "doalarm-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1640353650,
-        "narHash": "sha256-N1t6M3/wqj90AEdRkeC8i923gQYUpzSr8b40qVOZ1Rk=",
-        "owner": "haskell",
-        "repo": "cabal",
-        "rev": "942639c18c0cd8ec53e0a6f8d120091af35312cd",
+        "lastModified": 1690899975,
+        "narHash": "sha256-MwVSVkYio424ujh5cEr5stBmEURmDA9PNvqz1ShEtCM=",
+        "owner": "msooseth",
+        "repo": "doalarm",
+        "rev": "a208c35657b6465bd0d032b156bda87580e3eac3",
         "type": "github"
       },
       "original": {
-        "owner": "haskell",
-        "ref": "3.4",
-        "repo": "cabal",
-        "type": "github"
-      }
-    },
-    "cabal-36": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1641652457,
-        "narHash": "sha256-BlFPKP4C4HRUJeAbdembX1Rms1LD380q9s0qVDeoAak=",
-        "owner": "haskell",
-        "repo": "cabal",
-        "rev": "f27667f8ec360c475027dcaee0138c937477b070",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "3.6",
-        "repo": "cabal",
-        "type": "github"
-      }
-    },
-    "cardano-shell": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1608537748,
-        "narHash": "sha256-PulY1GfiMgKVnBci3ex4ptk2UNYMXqGjJOxcPy2KYT4=",
-        "owner": "input-output-hk",
-        "repo": "cardano-shell",
-        "rev": "9392c75087cb9a3d453998f4230930dea3a95725",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "repo": "cardano-shell",
-        "type": "github"
-      }
-    },
-    "cpp-httplib": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1595279716,
-        "narHash": "sha256-cZW/iEwlaB4UQ0OQLNqboY9addncIM/OsxxPzqmATmE=",
-        "owner": "yhirose",
-        "repo": "cpp-httplib",
-        "rev": "72ce293fed9f9335e92c95ab7d085feed18c0ee8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "yhirose",
-        "repo": "cpp-httplib",
-        "rev": "72ce293fed9f9335e92c95ab7d085feed18c0ee8",
-        "type": "github"
-      }
-    },
-    "cryptopp": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1632484127,
-        "narHash": "sha256-a3TYaK34WvKEXN7LKAfGwQ3ZL6a3k/zMZyyVfnkQqO4=",
-        "owner": "weidai11",
-        "repo": "cryptopp",
-        "rev": "69bf6b53052b59ccb57ce068ce741988ae087317",
-        "type": "github"
-      },
-      "original": {
-        "owner": "weidai11",
-        "repo": "cryptopp",
-        "rev": "69bf6b53052b59ccb57ce068ce741988ae087317",
-        "type": "github"
-      }
-    },
-    "devshell": {
-      "inputs": {
-        "flake-utils": [
-          "kevm",
-          "k-framework",
-          "haskell-backend",
-          "haskell-nix",
-          "tullia",
-          "std",
-          "flake-utils"
-        ],
-        "nixpkgs": [
-          "kevm",
-          "k-framework",
-          "haskell-backend",
-          "haskell-nix",
-          "tullia",
-          "std",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1663445644,
-        "narHash": "sha256-+xVlcK60x7VY1vRJbNUEAHi17ZuoQxAIH4S4iUFUGBA=",
-        "owner": "numtide",
-        "repo": "devshell",
-        "rev": "e3dc3e21594fe07bdb24bdf1c8657acaa4cb8f66",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "devshell",
-        "type": "github"
-      }
-    },
-    "dmerge": {
-      "inputs": {
-        "nixlib": [
-          "kevm",
-          "k-framework",
-          "haskell-backend",
-          "haskell-nix",
-          "tullia",
-          "std",
-          "nixpkgs"
-        ],
-        "yants": [
-          "kevm",
-          "k-framework",
-          "haskell-backend",
-          "haskell-nix",
-          "tullia",
-          "std",
-          "yants"
-        ]
-      },
-      "locked": {
-        "lastModified": 1659548052,
-        "narHash": "sha256-fzI2gp1skGA8mQo/FBFrUAtY0GQkAIAaV/V127TJPyY=",
-        "owner": "divnix",
-        "repo": "data-merge",
-        "rev": "d160d18ce7b1a45b88344aa3f13ed1163954b497",
-        "type": "github"
-      },
-      "original": {
-        "owner": "divnix",
-        "repo": "data-merge",
+        "owner": "msooseth",
+        "repo": "doalarm",
         "type": "github"
       }
     },
@@ -261,67 +40,33 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1681932842,
-        "narHash": "sha256-w9tt80k17iK3m+2DO9eb1G8xzQ/ywLTccSrLNJWQUJ0=",
+        "lastModified": 1689869819,
+        "narHash": "sha256-5d9ttPR3rRHywBeLM85EGCEZLNZNZzOAhIN6AJToJyI=",
         "owner": "crytic",
         "repo": "echidna",
-        "rev": "b02213bb0e89aef77dc8c68ecffdf36dccda6ac4",
+        "rev": "21e6e5282a4f5c8e6830d33286c47fddc101d7fa",
         "type": "github"
       },
       "original": {
         "owner": "crytic",
         "repo": "echidna",
-        "type": "github"
-      }
-    },
-    "ethereum-legacytests": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1633533576,
-        "narHash": "sha256-43lkAi6Z492pbHV+jySYXzvNtoGEGsndnBkxfYgmqFM=",
-        "owner": "ethereum",
-        "repo": "legacytests",
-        "rev": "d7abc42a7b352a7b44b1f66b58aca54e4af6a9d7",
-        "type": "github"
-      },
-      "original": {
-        "owner": "ethereum",
-        "repo": "legacytests",
-        "rev": "d7abc42a7b352a7b44b1f66b58aca54e4af6a9d7",
         "type": "github"
       }
     },
     "ethereum-tests": {
       "flake": false,
       "locked": {
-        "lastModified": 1668955227,
-        "narHash": "sha256-t9GV1TUfXr6xwgRvCaf43oGhBLdlYJwNCmaR4rIYV1M=",
+        "lastModified": 1682506704,
+        "narHash": "sha256-PyFZhdUQRUbmohoMS+w41rmSFfKeTO2RqHLetWlU4Jw=",
         "owner": "ethereum",
         "repo": "tests",
-        "rev": "a16217cff68fa587a4a8b8b008e5cf374a6086b5",
+        "rev": "b25623d4d7df10e38498cace7adc7eb413c4b20d",
         "type": "github"
       },
       "original": {
         "owner": "ethereum",
-        "ref": "v11.2",
+        "ref": "v12.2",
         "repo": "tests",
-        "type": "github"
-      }
-    },
-    "ethereum-tests_2": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1637090666,
-        "narHash": "sha256-B3fMpp/dpnwtCQzxI45kptJVwIM/kMo9hptcMP2B5n0=",
-        "owner": "ethereum",
-        "repo": "tests",
-        "rev": "6401889dec4eee58e808fd178fb2c7f628a3e039",
-        "type": "github"
-      },
-      "original": {
-        "owner": "ethereum",
-        "repo": "tests",
-        "rev": "6401889dec4eee58e808fd178fb2c7f628a3e039",
         "type": "github"
       }
     },
@@ -357,55 +102,6 @@
         "type": "github"
       }
     },
-    "flake-compat_3": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1673956053,
-        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
-    "flake-compat_4": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1672831974,
-        "narHash": "sha256-z9k3MfslLjWQfnjBtEtJZdq3H7kyi2kQtUThfTgdRk0=",
-        "owner": "input-output-hk",
-        "repo": "flake-compat",
-        "rev": "45f2638735f8cdc40fe302742b79f248d23eb368",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "ref": "hkm/gitlab-fix",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
-    "flake-compat_5": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1650374568,
-        "narHash": "sha256-Z+s0J8/r907g149rllvwhb4pKi8Wam5ij0st8PwAh+E=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "b4a34015c698c7793d592d66adbab377907a2be8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -424,46 +120,16 @@
         "type": "github"
       }
     },
-    "flake-utils_10": {
-      "locked": {
-        "lastModified": 1653893745,
-        "narHash": "sha256-0jntwV3Z8//YwuOjzhV2sgJJPt+HY6KhU7VZUL0fKZQ=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "1ed9fb1935d260de5fe1c2f7ee0ebaae17ed2fa1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_11": {
-      "locked": {
-        "lastModified": 1678901627,
-        "narHash": "sha256-U02riOqrKKzwjsxc/400XnElV+UtPUQWpANPlyazjH0=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "93a2b84fc4b70d9e089d029deacc3583435c2ed6",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "flake-utils_2": {
       "inputs": {
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1681202837,
-        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
+        "lastModified": 1689068808,
+        "narHash": "sha256-6ixXo3wt24N/melDWjq70UuHQLxGV8jZvooRanIHXw0=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
+        "rev": "919d646de7be200f3bf08cb76ae1f09402b6f9b4",
         "type": "github"
       },
       "original": {
@@ -488,12 +154,15 @@
       }
     },
     "flake-utils_4": {
+      "inputs": {
+        "systems": "systems_3"
+      },
       "locked": {
-        "lastModified": 1678901627,
-        "narHash": "sha256-U02riOqrKKzwjsxc/400XnElV+UtPUQWpANPlyazjH0=",
+        "lastModified": 1687709756,
+        "narHash": "sha256-Y5wKlQSkgEK2weWdOu4J3riRd+kV/VCgHsqLNTTWQ/0=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "93a2b84fc4b70d9e089d029deacc3583435c2ed6",
+        "rev": "dbabf0ca0c0c4bce6ea5eaf65af5cb694d2082c7",
         "type": "github"
       },
       "original": {
@@ -517,97 +186,17 @@
         "type": "github"
       }
     },
-    "flake-utils_6": {
-      "inputs": {
-        "systems": "systems_3"
-      },
-      "locked": {
-        "lastModified": 1681202837,
-        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_7": {
-      "locked": {
-        "lastModified": 1644229661,
-        "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_8": {
-      "locked": {
-        "lastModified": 1653893745,
-        "narHash": "sha256-0jntwV3Z8//YwuOjzhV2sgJJPt+HY6KhU7VZUL0fKZQ=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "1ed9fb1935d260de5fe1c2f7ee0ebaae17ed2fa1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_9": {
-      "locked": {
-        "lastModified": 1659877975,
-        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "fmt-src": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1661615830,
-        "narHash": "sha256-rP6ymyRc7LnKxUXwPpzhHOQvpJkpnRFOt2ctvUNlYI0=",
-        "owner": "fmtlib",
-        "repo": "fmt",
-        "rev": "a33701196adfad74917046096bf5a2aa0ab0bb50",
-        "type": "github"
-      },
-      "original": {
-        "owner": "fmtlib",
-        "ref": "9.1.0",
-        "repo": "fmt",
-        "type": "github"
-      }
-    },
     "foundry": {
       "inputs": {
         "flake-utils": "flake-utils_3",
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1680599605,
-        "narHash": "sha256-U7BvAOvULf6IA40M4MLYZKxIMyqTzhMvKlAkuDqRMTI=",
+        "lastModified": 1688462028,
+        "narHash": "sha256-+43L9rwbNC1cO0LrinxjaolmyIH/STpL67uf2s6+6C0=",
         "owner": "shazow",
         "repo": "foundry.nix",
-        "rev": "e3e0951e0cb668e7796f1fde2926ff32dc544d49",
+        "rev": "e8fb5553c880942ac5215fb210ada54841605c62",
         "type": "github"
       },
       "original": {
@@ -623,11 +212,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1677921223,
-        "narHash": "sha256-TsrPW+VfLu19dYm4uuAaM9LLHm30iZiyW1+0mbFgwbk=",
+        "lastModified": 1688462028,
+        "narHash": "sha256-+43L9rwbNC1cO0LrinxjaolmyIH/STpL67uf2s6+6C0=",
         "owner": "shazow",
         "repo": "foundry.nix",
-        "rev": "79df1481c10789570c40749a4c8f8aada16f2eea",
+        "rev": "e8fb5553c880942ac5215fb210ada54841605c62",
         "type": "github"
       },
       "original": {
@@ -637,474 +226,43 @@
         "type": "github"
       }
     },
-    "ghc-8.6.5-iohk": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1600920045,
-        "narHash": "sha256-DO6kxJz248djebZLpSzTGD6s8WRpNI9BTwUeOf5RwY8=",
-        "owner": "input-output-hk",
-        "repo": "ghc",
-        "rev": "95713a6ecce4551240da7c96b6176f980af75cae",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "ref": "release/8.6.5-iohk",
-        "repo": "ghc",
-        "type": "github"
-      }
-    },
-    "gomod2nix": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_6",
-        "utils": "utils"
-      },
-      "locked": {
-        "lastModified": 1655245309,
-        "narHash": "sha256-d/YPoQ/vFn1+GTmSdvbSBSTOai61FONxB4+Lt6w/IVI=",
-        "owner": "tweag",
-        "repo": "gomod2nix",
-        "rev": "40d32f82fc60d66402eb0972e6e368aeab3faf58",
-        "type": "github"
-      },
-      "original": {
-        "owner": "tweag",
-        "repo": "gomod2nix",
-        "type": "github"
-      }
-    },
-    "hackage": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1674692755,
-        "narHash": "sha256-p/FnWnCFNF6bqU3lyUJgKUsKEEoeZPOoBdTLqU2O4R0=",
-        "owner": "input-output-hk",
-        "repo": "hackage.nix",
-        "rev": "47b88d3591e159961e149de9381a35dc8dc62cfb",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "repo": "hackage.nix",
-        "type": "github"
-      }
-    },
     "halmos-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1679459996,
-        "narHash": "sha256-9li0QwjG4vDkGCTcEoXJ6gK6qT2y1eztnHR2aU1Dch4=",
+        "lastModified": 1690676552,
+        "narHash": "sha256-KB+Sm8ZdM0pnFpRSA4LOkuEGfk/o3tJq37q/FxAssqw=",
         "owner": "a16z",
         "repo": "halmos",
-        "rev": "1cbfb7af4ff5dc5d4c47fba19f9004c929c35e8d",
+        "rev": "48e780069caa45b681db1f75b9d9cc4c4f005c44",
         "type": "github"
       },
       "original": {
         "owner": "a16z",
         "repo": "halmos",
-        "type": "github"
-      }
-    },
-    "haskell-backend": {
-      "inputs": {
-        "haskell-nix": "haskell-nix",
-        "nixpkgs": [
-          "kevm",
-          "k-framework",
-          "haskell-backend",
-          "haskell-nix",
-          "nixpkgs-unstable"
-        ],
-        "nixpkgs22_05": "nixpkgs22_05",
-        "z3-src": "z3-src"
-      },
-      "locked": {
-        "lastModified": 1681831596,
-        "narHash": "sha256-WlyPBEuJtpDuLGNGroo1stZ7phl4h0pusPErC7ehArQ=",
-        "owner": "runtimeverification",
-        "repo": "haskell-backend",
-        "rev": "9968f3e5b7b649a12cf143da4c67fddf627eabb8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "runtimeverification",
-        "repo": "haskell-backend",
-        "type": "github"
-      }
-    },
-    "haskell-nix": {
-      "inputs": {
-        "HTTP": "HTTP",
-        "cabal-32": "cabal-32",
-        "cabal-34": "cabal-34",
-        "cabal-36": "cabal-36",
-        "cardano-shell": "cardano-shell",
-        "flake-compat": "flake-compat_4",
-        "flake-utils": "flake-utils_7",
-        "ghc-8.6.5-iohk": "ghc-8.6.5-iohk",
-        "hackage": "hackage",
-        "hpc-coveralls": "hpc-coveralls",
-        "hydra": "hydra",
-        "iserv-proxy": "iserv-proxy",
-        "nixpkgs": [
-          "kevm",
-          "k-framework",
-          "haskell-backend",
-          "haskell-nix",
-          "nixpkgs-unstable"
-        ],
-        "nixpkgs-2003": "nixpkgs-2003",
-        "nixpkgs-2105": "nixpkgs-2105",
-        "nixpkgs-2111": "nixpkgs-2111",
-        "nixpkgs-2205": "nixpkgs-2205",
-        "nixpkgs-2211": "nixpkgs-2211",
-        "nixpkgs-unstable": "nixpkgs-unstable",
-        "old-ghc-nix": "old-ghc-nix",
-        "stackage": "stackage",
-        "tullia": "tullia"
-      },
-      "locked": {
-        "lastModified": 1674694244,
-        "narHash": "sha256-WiRjhSOxIqBwAP39VPf4ZrCqPK2Jf58up2xyk3tYyxI=",
-        "owner": "input-output-hk",
-        "repo": "haskell.nix",
-        "rev": "418612f2f2b814ae6161682fb3770c3c86c41b44",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "repo": "haskell.nix",
         "type": "github"
       }
     },
     "hevm": {
       "inputs": {
+        "cabal-head": "cabal-head",
         "ethereum-tests": "ethereum-tests",
         "flake-compat": "flake-compat_2",
         "flake-utils": "flake-utils_4",
         "foundry": "foundry_2",
         "nixpkgs": "nixpkgs_4",
-        "nixpkgs-solc": "nixpkgs-solc",
         "solidity": "solidity"
       },
       "locked": {
-        "lastModified": 1681911003,
-        "narHash": "sha256-Kp3rDP2hjs+E0Dx4ywt+PiFsFjr0C/Z+Tjf11bnGbQE=",
+        "lastModified": 1690823940,
+        "narHash": "sha256-ZT0oGINdw8oP6EKeL0BvnoMv4HcZZXbw0dTehy3vU1I=",
         "owner": "ethereum",
         "repo": "hevm",
-        "rev": "c66e8830cf1dfbcc64bea4659962f90daf4e22aa",
+        "rev": "135fdd711c8410e4be15083c7e02aa24cec83c63",
         "type": "github"
       },
       "original": {
         "owner": "ethereum",
         "repo": "hevm",
-        "type": "github"
-      }
-    },
-    "hpc-coveralls": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1607498076,
-        "narHash": "sha256-8uqsEtivphgZWYeUo5RDUhp6bO9j2vaaProQxHBltQk=",
-        "owner": "sevanspowell",
-        "repo": "hpc-coveralls",
-        "rev": "14df0f7d229f4cd2e79f8eabb1a740097fdfa430",
-        "type": "github"
-      },
-      "original": {
-        "owner": "sevanspowell",
-        "repo": "hpc-coveralls",
-        "type": "github"
-      }
-    },
-    "hydra": {
-      "inputs": {
-        "nix": "nix",
-        "nixpkgs": [
-          "kevm",
-          "k-framework",
-          "haskell-backend",
-          "haskell-nix",
-          "hydra",
-          "nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1646878427,
-        "narHash": "sha256-KtbrofMtN8GlM7D+n90kixr7QpSlVmdN+vK5CA/aRzc=",
-        "owner": "NixOS",
-        "repo": "hydra",
-        "rev": "28b682b85b7efc5cf7974065792a1f22203a5927",
-        "type": "github"
-      },
-      "original": {
-        "id": "hydra",
-        "type": "indirect"
-      }
-    },
-    "immer-src": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1634324349,
-        "narHash": "sha256-1OicqmyM3Rcrs/jkRMip2pXITQnVDRrHbQbEpZZ4nnU=",
-        "owner": "runtimeverification",
-        "repo": "immer",
-        "rev": "198c2ae260d49ef1800a2fe4433e07d7dec20059",
-        "type": "github"
-      },
-      "original": {
-        "owner": "runtimeverification",
-        "repo": "immer",
-        "rev": "198c2ae260d49ef1800a2fe4433e07d7dec20059",
-        "type": "github"
-      }
-    },
-    "iserv-proxy": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1670983692,
-        "narHash": "sha256-avLo34JnI9HNyOuauK5R69usJm+GfW3MlyGlYxZhTgY=",
-        "ref": "hkm/remote-iserv",
-        "rev": "50d0abb3317ac439a4e7495b185a64af9b7b9300",
-        "revCount": 10,
-        "type": "git",
-        "url": "https://gitlab.haskell.org/hamishmack/iserv-proxy.git"
-      },
-      "original": {
-        "ref": "hkm/remote-iserv",
-        "type": "git",
-        "url": "https://gitlab.haskell.org/hamishmack/iserv-proxy.git"
-      }
-    },
-    "k-framework": {
-      "inputs": {
-        "flake-compat": "flake-compat_3",
-        "flake-utils": "flake-utils_6",
-        "haskell-backend": "haskell-backend",
-        "llvm-backend": "llvm-backend",
-        "mavenix": "mavenix_2",
-        "nixpkgs": [
-          "kevm",
-          "nixpkgs"
-        ],
-        "rv-utils": "rv-utils"
-      },
-      "locked": {
-        "lastModified": 1681860253,
-        "narHash": "sha256-UFIN7fzS7W7vh3JrAvtIt0uLap/hjs4haRaUcUklp5A=",
-        "owner": "runtimeverification",
-        "repo": "k",
-        "rev": "2c44743d8d150e00ba4671b299e9fe3f7f75d727",
-        "type": "github"
-      },
-      "original": {
-        "owner": "runtimeverification",
-        "ref": "v5.6.56",
-        "repo": "k",
-        "type": "github"
-      }
-    },
-    "kevm": {
-      "inputs": {
-        "blockchain-k-plugin": "blockchain-k-plugin",
-        "ethereum-legacytests": "ethereum-legacytests",
-        "ethereum-tests": "ethereum-tests_2",
-        "flake-utils": [
-          "kevm",
-          "k-framework",
-          "flake-utils"
-        ],
-        "haskell-backend": [
-          "kevm",
-          "k-framework",
-          "haskell-backend"
-        ],
-        "k-framework": "k-framework",
-        "nixpkgs": "nixpkgs_11",
-        "poetry2nix": [
-          "kevm",
-          "pyk",
-          "poetry2nix"
-        ],
-        "pyk": "pyk",
-        "rv-utils": "rv-utils_2"
-      },
-      "locked": {
-        "lastModified": 1681989684,
-        "narHash": "sha256-dX5x/hDcbL67n97sR9bG+rg1eUdsXPl2OCWxAFrx7Os=",
-        "owner": "runtimeverification",
-        "repo": "evm-semantics",
-        "rev": "862aedd14de28089f261575fa0bb9b989761d1a0",
-        "type": "github"
-      },
-      "original": {
-        "owner": "runtimeverification",
-        "repo": "evm-semantics",
-        "type": "github"
-      }
-    },
-    "libff": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1588032522,
-        "narHash": "sha256-I0kH2XLvHDSrdL/o4i6XozWQJV0UDv9zH6+sWS0UQHg=",
-        "owner": "scipr-lab",
-        "repo": "libff",
-        "rev": "5835b8c59d4029249645cf551f417608c48f2770",
-        "type": "github"
-      },
-      "original": {
-        "owner": "scipr-lab",
-        "repo": "libff",
-        "rev": "5835b8c59d4029249645cf551f417608c48f2770",
-        "type": "github"
-      }
-    },
-    "llvm-backend": {
-      "inputs": {
-        "fmt-src": "fmt-src",
-        "immer-src": "immer-src",
-        "mavenix": "mavenix",
-        "nixpkgs": [
-          "kevm",
-          "k-framework",
-          "haskell-backend",
-          "nixpkgs"
-        ],
-        "pybind11-src": "pybind11-src",
-        "rapidjson-src": "rapidjson-src",
-        "utils": "utils_3"
-      },
-      "locked": {
-        "lastModified": 1681763129,
-        "narHash": "sha256-2wigCF/+7dKtaYPFIBvGoVPXaKjRX6KhWtRV380f1mw=",
-        "owner": "runtimeverification",
-        "repo": "llvm-backend",
-        "rev": "e46a597fd85286d5d6930ba92c990a161b7676d3",
-        "type": "github"
-      },
-      "original": {
-        "owner": "runtimeverification",
-        "repo": "llvm-backend",
-        "type": "github"
-      }
-    },
-    "lowdown-src": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1633514407,
-        "narHash": "sha256-Dw32tiMjdK9t3ETl5fzGrutQTzh2rufgZV4A/BbxuD4=",
-        "owner": "kristapsdz",
-        "repo": "lowdown",
-        "rev": "d2c2b44ff6c27b936ec27358a2653caaef8f73b8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "kristapsdz",
-        "repo": "lowdown",
-        "type": "github"
-      }
-    },
-    "mavenix": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_9",
-        "utils": "utils_2"
-      },
-      "locked": {
-        "lastModified": 1643802645,
-        "narHash": "sha256-BynM25iwp/l3FyrcHqiNJdDxvN6IxSM3/zkFR6PD3B0=",
-        "owner": "nix-community",
-        "repo": "mavenix",
-        "rev": "ce9ddfd7f361190e8e8dcfaf6b8282eebbb3c7cb",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "mavenix",
-        "type": "github"
-      }
-    },
-    "mavenix_2": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_10",
-        "utils": "utils_4"
-      },
-      "locked": {
-        "lastModified": 1656435814,
-        "narHash": "sha256-Gx4QoWB9eI437/66iqTr6AUjxGgN6WslqrQ57s+sL6A=",
-        "owner": "goodlyrottenapple",
-        "repo": "mavenix",
-        "rev": "0cbd57b2494d52909b27f57d03580acc66bf0298",
-        "type": "github"
-      },
-      "original": {
-        "owner": "goodlyrottenapple",
-        "repo": "mavenix",
-        "type": "github"
-      }
-    },
-    "mdbook-kroki-preprocessor": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1661755005,
-        "narHash": "sha256-1TJuUzfyMycWlOQH67LR63/ll2GDZz25I3JfScy/Jnw=",
-        "owner": "JoelCourtney",
-        "repo": "mdbook-kroki-preprocessor",
-        "rev": "93adb5716d035829efed27f65f2f0833a7d3e76f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "JoelCourtney",
-        "repo": "mdbook-kroki-preprocessor",
-        "type": "github"
-      }
-    },
-    "n2c": {
-      "inputs": {
-        "flake-utils": "flake-utils_10",
-        "nixpkgs": [
-          "kevm",
-          "k-framework",
-          "haskell-backend",
-          "haskell-nix",
-          "tullia",
-          "std",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1665039323,
-        "narHash": "sha256-SAh3ZjFGsaCI8FRzXQyp56qcGdAqgKEfJWPCQ0Sr7tQ=",
-        "owner": "nlewo",
-        "repo": "nix2container",
-        "rev": "b008fe329ffb59b67bf9e7b08ede6ee792f2741a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nlewo",
-        "repo": "nix2container",
-        "type": "github"
-      }
-    },
-    "nix": {
-      "inputs": {
-        "lowdown-src": "lowdown-src",
-        "nixpkgs": "nixpkgs_5",
-        "nixpkgs-regression": "nixpkgs-regression"
-      },
-      "locked": {
-        "lastModified": 1643066034,
-        "narHash": "sha256-xEPeMcNJVOeZtoN+d+aRwolpW8mFSEQx76HTRdlhPhg=",
-        "owner": "NixOS",
-        "repo": "nix",
-        "rev": "a1cd7e58606a41fcf62bf8637804cf8306f17f62",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "2.6.0",
-        "repo": "nix",
         "type": "github"
       }
     },
@@ -1124,113 +282,6 @@
         "type": "github"
       }
     },
-    "nix-nomad": {
-      "inputs": {
-        "flake-compat": "flake-compat_5",
-        "flake-utils": [
-          "kevm",
-          "k-framework",
-          "haskell-backend",
-          "haskell-nix",
-          "tullia",
-          "nix2container",
-          "flake-utils"
-        ],
-        "gomod2nix": "gomod2nix",
-        "nixpkgs": [
-          "kevm",
-          "k-framework",
-          "haskell-backend",
-          "haskell-nix",
-          "tullia",
-          "nixpkgs"
-        ],
-        "nixpkgs-lib": [
-          "kevm",
-          "k-framework",
-          "haskell-backend",
-          "haskell-nix",
-          "tullia",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1658277770,
-        "narHash": "sha256-T/PgG3wUn8Z2rnzfxf2VqlR1CBjInPE0l1yVzXxPnt0=",
-        "owner": "tristanpemble",
-        "repo": "nix-nomad",
-        "rev": "054adcbdd0a836ae1c20951b67ed549131fd2d70",
-        "type": "github"
-      },
-      "original": {
-        "owner": "tristanpemble",
-        "repo": "nix-nomad",
-        "type": "github"
-      }
-    },
-    "nix2container": {
-      "inputs": {
-        "flake-utils": "flake-utils_8",
-        "nixpkgs": "nixpkgs_7"
-      },
-      "locked": {
-        "lastModified": 1658567952,
-        "narHash": "sha256-XZ4ETYAMU7XcpEeAFP3NOl9yDXNuZAen/aIJ84G+VgA=",
-        "owner": "nlewo",
-        "repo": "nix2container",
-        "rev": "60bb43d405991c1378baf15a40b5811a53e32ffa",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nlewo",
-        "repo": "nix2container",
-        "type": "github"
-      }
-    },
-    "nixago": {
-      "inputs": {
-        "flake-utils": [
-          "kevm",
-          "k-framework",
-          "haskell-backend",
-          "haskell-nix",
-          "tullia",
-          "std",
-          "flake-utils"
-        ],
-        "nixago-exts": [
-          "kevm",
-          "k-framework",
-          "haskell-backend",
-          "haskell-nix",
-          "tullia",
-          "std",
-          "blank"
-        ],
-        "nixpkgs": [
-          "kevm",
-          "k-framework",
-          "haskell-backend",
-          "haskell-nix",
-          "tullia",
-          "std",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1661824785,
-        "narHash": "sha256-/PnwdWoO/JugJZHtDUioQp3uRiWeXHUdgvoyNbXesz8=",
-        "owner": "nix-community",
-        "repo": "nixago",
-        "rev": "8c1f9e5f1578d4b2ea989f618588d62a335083c3",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "nixago",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1681205926,
@@ -1242,193 +293,6 @@
       },
       "original": {
         "owner": "NixOS",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-2003": {
-      "locked": {
-        "lastModified": 1620055814,
-        "narHash": "sha256-8LEHoYSJiL901bTMVatq+rf8y7QtWuZhwwpKE2fyaRY=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "1db42b7fe3878f3f5f7a4f2dc210772fd080e205",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-20.03-darwin",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-2105": {
-      "locked": {
-        "lastModified": 1659914493,
-        "narHash": "sha256-lkA5X3VNMKirvA+SUzvEhfA7XquWLci+CGi505YFAIs=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "022caabb5f2265ad4006c1fa5b1ebe69fb0c3faf",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-21.05-darwin",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-2111": {
-      "locked": {
-        "lastModified": 1659446231,
-        "narHash": "sha256-hekabNdTdgR/iLsgce5TGWmfIDZ86qjPhxDg/8TlzhE=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "eabc38219184cc3e04a974fe31857d8e0eac098d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-21.11-darwin",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-2205": {
-      "locked": {
-        "lastModified": 1663981975,
-        "narHash": "sha256-TKaxWAVJR+a5JJauKZqibmaM5e/Pi5tBDx9s8fl/kSE=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "309faedb8338d3ae8ad8f1043b3ccf48c9cc2970",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-22.05-darwin",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-2211": {
-      "locked": {
-        "lastModified": 1669997163,
-        "narHash": "sha256-vhjC0kZMFoN6jzK0GR+tBzKi5KgBXgehadfidW8+Va4=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "6f87491a54d8d64d30af6663cb3bf5d2ee7db958",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-22.11-darwin",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-regression": {
-      "locked": {
-        "lastModified": 1643052045,
-        "narHash": "sha256-uGJ0VXIhWKGXxkeNnq4TvV3CIOkUJ3PAoLZ3HMzNVMw=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
-        "type": "github"
-      },
-      "original": {
-        "id": "nixpkgs",
-        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
-        "type": "indirect"
-      }
-    },
-    "nixpkgs-solc": {
-      "locked": {
-        "lastModified": 1672059513,
-        "narHash": "sha256-4R7lESB3biVNyE6rXkjw3mhowzg4zTQgZElM4/dRUv8=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "1b71def42b74811323de2df52f180b795ec506fc",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "1b71def42b74811323de2df52f180b795ec506fc",
-        "type": "github"
-      }
-    },
-    "nixpkgs-unstable": {
-      "locked": {
-        "lastModified": 1663905476,
-        "narHash": "sha256-0CSwRKaYravh9v6qSlBpM0gNg0UhKT2lL7Yn6Zbx7UM=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "e14f9fb57315f0d4abde222364f19f88c77d2b79",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs22_05": {
-      "locked": {
-        "lastModified": 1662099760,
-        "narHash": "sha256-MdZLCTJPeHi/9fg6R9fiunyDwP3XHJqDd51zWWz9px0=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "67e45078141102f45eff1589a831aeaa3182b41e",
-        "type": "github"
-      },
-      "original": {
-        "id": "nixpkgs",
-        "ref": "nixos-22.05",
-        "type": "indirect"
-      }
-    },
-    "nixpkgs_10": {
-      "locked": {
-        "lastModified": 1621552131,
-        "narHash": "sha256-AD/AEXv+QOYAg0PIqMYv2nbGOGTIwfOGKtz3rE+y+Tc=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "d42cd445dde587e9a993cd9434cb43da07c4c5de",
-        "type": "github"
-      },
-      "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
-      }
-    },
-    "nixpkgs_11": {
-      "locked": {
-        "lastModified": 1680577567,
-        "narHash": "sha256-Y4W57i0TzczqwMTjfVSbAZT5RJx7u+mpQIW/ofrkTQs=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b01f185e4866de7c5b5a82f833ca9ea3c3f72fc4",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b01f185e4866de7c5b5a82f833ca9ea3c3f72fc4",
-        "type": "github"
-      }
-    },
-    "nixpkgs_12": {
-      "locked": {
-        "lastModified": 1681993866,
-        "narHash": "sha256-cc26r+rU4gB9lZFKASHClY+pcoCbZeUbK5R+NoASb48=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "d5845e88f84a1d97dbd658ea6095e26880aa3a1c",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -1463,272 +327,44 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1679402239,
-        "narHash": "sha256-xJLprGQf4v0cKNtWaI2tMvn+tuYir3yNAFd41CWNgAw=",
+        "lastModified": 1688961476,
+        "narHash": "sha256-oYcCy27BdAfU5H5DDQ7vWdrhaIgRCZ5XASORrwrQAAg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9cc171df4617329f2c776fefe3ee83f1a0ffa046",
+        "rev": "3ba086a64b3997ee82e331abaf3af7049e3fc742",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
+        "ref": "haskell-updates",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1632864508,
-        "narHash": "sha256-d127FIvGR41XbVRDPVvozUPQ/uRHbHwvfyKHwEt5xFM=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "82891b5e2c2359d7e58d08849e4c89511ab94234",
-        "type": "github"
-      },
-      "original": {
-        "id": "nixpkgs",
-        "ref": "nixos-21.05-small",
-        "type": "indirect"
-      }
-    },
-    "nixpkgs_6": {
-      "locked": {
-        "lastModified": 1653581809,
-        "narHash": "sha256-Uvka0V5MTGbeOfWte25+tfRL3moECDh1VwokWSZUdoY=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "83658b28fe638a170a19b8933aa008b30640fbd1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_7": {
-      "locked": {
-        "lastModified": 1654807842,
-        "narHash": "sha256-ADymZpr6LuTEBXcy6RtFHcUZdjKTBRTMYwu19WOx17E=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "fc909087cc3386955f21b4665731dbdaceefb1d8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_8": {
-      "locked": {
-        "lastModified": 1665087388,
-        "narHash": "sha256-FZFPuW9NWHJteATOf79rZfwfRn5fE0wi9kRzvGfDHPA=",
+        "lastModified": 1690899495,
+        "narHash": "sha256-W6Znk/udyFvBOWtY2VPAeRHjVzH0C4mnXf8O1t55Olo=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "95fda953f6db2e9496d2682c4fc7b82f959878f7",
+        "rev": "7965b589f303dfe01e6128eb0b52654cc444715d",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_9": {
-      "locked": {
-        "lastModified": 1621552131,
-        "narHash": "sha256-AD/AEXv+QOYAg0PIqMYv2nbGOGTIwfOGKtz3rE+y+Tc=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "d42cd445dde587e9a993cd9434cb43da07c4c5de",
-        "type": "github"
-      },
-      "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
-      }
-    },
-    "old-ghc-nix": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1631092763,
-        "narHash": "sha256-sIKgO+z7tj4lw3u6oBZxqIhDrzSkvpHtv0Kki+lh9Fg=",
-        "owner": "angerman",
-        "repo": "old-ghc-nix",
-        "rev": "af48a7a7353e418119b6dfe3cd1463a657f342b8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "angerman",
-        "ref": "master",
-        "repo": "old-ghc-nix",
-        "type": "github"
-      }
-    },
-    "poetry2nix": {
-      "inputs": {
-        "flake-utils": "flake-utils_11",
-        "nixpkgs": [
-          "kevm",
-          "pyk",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1680067032,
-        "narHash": "sha256-RF07f1iZkJOdSbv+1myXdvgCxUsUjHdHBF7CEX3rnag=",
-        "owner": "nix-community",
-        "repo": "poetry2nix",
-        "rev": "39c356df8277758138829c7b3694e58fe8d4afa2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "ref": "master",
-        "repo": "poetry2nix",
-        "type": "github"
-      }
-    },
-    "pybind11-src": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1657936673,
-        "narHash": "sha256-/X8DZPFsNrKGbhjZ1GFOj17/NU6p4R+saCW3pLKVNeA=",
-        "owner": "pybind",
-        "repo": "pybind11",
-        "rev": "0ba639d6177659c5dc2955ac06ad7b5b0d22e05c",
-        "type": "github"
-      },
-      "original": {
-        "owner": "pybind",
-        "repo": "pybind11",
-        "rev": "0ba639d6177659c5dc2955ac06ad7b5b0d22e05c",
-        "type": "github"
-      }
-    },
-    "pyk": {
-      "inputs": {
-        "flake-utils": [
-          "kevm",
-          "k-framework",
-          "flake-utils"
-        ],
-        "nixpkgs": [
-          "kevm",
-          "k-framework",
-          "nixpkgs"
-        ],
-        "poetry2nix": "poetry2nix"
-      },
-      "locked": {
-        "lastModified": 1681980155,
-        "narHash": "sha256-Cjrw1XeTcinJmeaQrFPURq0UxZ/fUQB+NlrsgzUKODY=",
-        "owner": "runtimeverification",
-        "repo": "pyk",
-        "rev": "8f46c2602d8152be9b5e7e4a00a50e318653ae3f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "runtimeverification",
-        "ref": "v0.1.253",
-        "repo": "pyk",
-        "type": "github"
-      }
-    },
-    "rapidjson-src": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1472111945,
-        "narHash": "sha256-SxUXSOQDZ0/3zlFI4R84J56/1fkw2jhge4mexNF6Pco=",
-        "owner": "Tencent",
-        "repo": "rapidjson",
-        "rev": "f54b0e47a08782a6131cc3d60f94d038fa6e0a51",
-        "type": "github"
-      },
-      "original": {
-        "owner": "Tencent",
-        "repo": "rapidjson",
-        "rev": "f54b0e47a08782a6131cc3d60f94d038fa6e0a51",
         "type": "github"
       }
     },
     "root": {
       "inputs": {
+        "doalarm-src": "doalarm-src",
         "echidna": "echidna",
         "flake-utils": "flake-utils_2",
         "foundry": "foundry",
         "halmos-src": "halmos-src",
         "hevm": "hevm",
-        "kevm": "kevm",
-        "nixpkgs": "nixpkgs_12",
-        "runlim-src": "runlim-src"
-      }
-    },
-    "runlim-src": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1688487804,
-        "narHash": "sha256-HCaUP71ymtG1sRs6JWWvlJhYKECo/gcj2qBRU31WJxc=",
-        "owner": "msooseth",
-        "repo": "runlim",
-        "rev": "f1b263bc22b6d89e68dbb26bf3ea3508d74154ef",
-        "type": "github"
-      },
-      "original": {
-        "owner": "msooseth",
-        "repo": "runlim",
-        "type": "github"
-      }
-    },
-    "rv-utils": {
-      "locked": {
-        "lastModified": 1659349707,
-        "narHash": "sha256-+RwJvYwRS4In+pl8R5Uz+R/yZ5yO5SAa7X6UR+eSC2U=",
-        "owner": "runtimeverification",
-        "repo": "rv-nix-tools",
-        "rev": "7026604726c5247ceb6e7a1a7532302a58e7e2bf",
-        "type": "github"
-      },
-      "original": {
-        "owner": "runtimeverification",
-        "repo": "rv-nix-tools",
-        "type": "github"
-      }
-    },
-    "rv-utils_2": {
-      "locked": {
-        "lastModified": 1659349707,
-        "narHash": "sha256-+RwJvYwRS4In+pl8R5Uz+R/yZ5yO5SAa7X6UR+eSC2U=",
-        "owner": "runtimeverification",
-        "repo": "rv-nix-tools",
-        "rev": "7026604726c5247ceb6e7a1a7532302a58e7e2bf",
-        "type": "github"
-      },
-      "original": {
-        "owner": "runtimeverification",
-        "repo": "rv-nix-tools",
-        "type": "github"
-      }
-    },
-    "secp256k1": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1502408521,
-        "narHash": "sha256-PyqNZGER9VypH35S/aU4EBeepieI3BGXrYsJ141os24=",
-        "owner": "bitcoin-core",
-        "repo": "secp256k1",
-        "rev": "f532bdc9f77f7bbf7e93faabfbe9c483f0a9f75f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "bitcoin-core",
-        "repo": "secp256k1",
-        "rev": "f532bdc9f77f7bbf7e93faabfbe9c483f0a9f75f",
-        "type": "github"
+        "nixpkgs": "nixpkgs_5"
       }
     },
     "solidity": {
@@ -1745,66 +381,6 @@
         "owner": "ethereum",
         "repo": "solidity",
         "rev": "1c8745c54a239d20b6fb0f79a8bd2628d779b27e",
-        "type": "github"
-      }
-    },
-    "stackage": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1674605441,
-        "narHash": "sha256-GX5OHXYP6jRSlDq0KOpb4AXgeEU70zVTRQ/ogKg7vR4=",
-        "owner": "input-output-hk",
-        "repo": "stackage.nix",
-        "rev": "17e090ed82bc8aedaf251a8becb7ba2455db816a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "repo": "stackage.nix",
-        "type": "github"
-      }
-    },
-    "std": {
-      "inputs": {
-        "blank": "blank",
-        "devshell": "devshell",
-        "dmerge": "dmerge",
-        "flake-utils": "flake-utils_9",
-        "makes": [
-          "kevm",
-          "k-framework",
-          "haskell-backend",
-          "haskell-nix",
-          "tullia",
-          "std",
-          "blank"
-        ],
-        "mdbook-kroki-preprocessor": "mdbook-kroki-preprocessor",
-        "microvm": [
-          "kevm",
-          "k-framework",
-          "haskell-backend",
-          "haskell-nix",
-          "tullia",
-          "std",
-          "blank"
-        ],
-        "n2c": "n2c",
-        "nixago": "nixago",
-        "nixpkgs": "nixpkgs_8",
-        "yants": "yants"
-      },
-      "locked": {
-        "lastModified": 1665513321,
-        "narHash": "sha256-D6Pacw9yf/HMs84KYuCxHXnNDL7v43gtcka5URagFqE=",
-        "owner": "divnix",
-        "repo": "std",
-        "rev": "94a90eedb9cfc115b12ae8f6622d9904788559e4",
-        "type": "github"
-      },
-      "original": {
-        "owner": "divnix",
-        "repo": "std",
         "type": "github"
       }
     },
@@ -1850,153 +426,6 @@
       "original": {
         "owner": "nix-systems",
         "repo": "default",
-        "type": "github"
-      }
-    },
-    "tullia": {
-      "inputs": {
-        "nix-nomad": "nix-nomad",
-        "nix2container": "nix2container",
-        "nixpkgs": [
-          "kevm",
-          "k-framework",
-          "haskell-backend",
-          "haskell-nix",
-          "nixpkgs"
-        ],
-        "std": "std"
-      },
-      "locked": {
-        "lastModified": 1668711738,
-        "narHash": "sha256-CBjky16o9pqsGE1bWu6nRlRajgSXMEk+yaFQLibqXcE=",
-        "owner": "input-output-hk",
-        "repo": "tullia",
-        "rev": "ead1f515c251f0e060060ef0e2356a51d3dfe4b0",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "repo": "tullia",
-        "type": "github"
-      }
-    },
-    "utils": {
-      "locked": {
-        "lastModified": 1653893745,
-        "narHash": "sha256-0jntwV3Z8//YwuOjzhV2sgJJPt+HY6KhU7VZUL0fKZQ=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "1ed9fb1935d260de5fe1c2f7ee0ebaae17ed2fa1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "utils_2": {
-      "locked": {
-        "lastModified": 1620759905,
-        "narHash": "sha256-WiyWawrgmyN0EdmiHyG2V+fqReiVi8bM9cRdMaKQOFg=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "b543720b25df6ffdfcf9227afafc5b8c1fabfae8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "utils_3": {
-      "locked": {
-        "lastModified": 1667395993,
-        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "utils_4": {
-      "locked": {
-        "lastModified": 1620759905,
-        "narHash": "sha256-WiyWawrgmyN0EdmiHyG2V+fqReiVi8bM9cRdMaKQOFg=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "b543720b25df6ffdfcf9227afafc5b8c1fabfae8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "xbyak": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1518572786,
-        "narHash": "sha256-jqDSNDcqK7010ig941hrJFkv1X7MbgXmhPOOE9wHmho=",
-        "owner": "herumi",
-        "repo": "xbyak",
-        "rev": "f0a8f7faa27121f28186c2a7f4222a9fc66c283d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "herumi",
-        "repo": "xbyak",
-        "rev": "f0a8f7faa27121f28186c2a7f4222a9fc66c283d",
-        "type": "github"
-      }
-    },
-    "yants": {
-      "inputs": {
-        "nixpkgs": [
-          "kevm",
-          "k-framework",
-          "haskell-backend",
-          "haskell-nix",
-          "tullia",
-          "std",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1660507851,
-        "narHash": "sha256-BKjq7JnVuUR/xDtcv6Vm9GYGKAblisXrAgybor9hT/s=",
-        "owner": "divnix",
-        "repo": "yants",
-        "rev": "0b895ca02a8fa72bad50b454cb3e7d8a66407c96",
-        "type": "github"
-      },
-      "original": {
-        "owner": "divnix",
-        "repo": "yants",
-        "type": "github"
-      }
-    },
-    "z3-src": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1647807944,
-        "narHash": "sha256-hXlwaLsrMKm0rPAhRtynCjdhkeXIYzfNcjS04sHHfHY=",
-        "owner": "Z3Prover",
-        "repo": "z3",
-        "rev": "f1806d32d6f21fd4df7a08719abbc1f6493d9dc5",
-        "type": "github"
-      },
-      "original": {
-        "owner": "Z3Prover",
-        "ref": "z3-4.8.15",
-        "repo": "z3",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -6,15 +6,15 @@
     nixpkgs.url = "github:nixos/nixpkgs";
 
     hevm.url = "github:ethereum/hevm";
-    kevm.url = "github:runtimeverification/evm-semantics";
+    # kevm.url = "github:runtimeverification/evm-semantics";
     foundry.url = "github:shazow/foundry.nix/monthly";
     echidna.url = "github:crytic/echidna";
     halmos-src = {
       url = "github:a16z/halmos";
       flake = false;
     };
-    runlim-src = {
-      url = "github:msooseth/runlim";
+    doalarm-src = {
+      url = "github:msooseth/doalarm";
       flake = false;
     };
   };
@@ -24,18 +24,19 @@
     extra-trusted-public-keys = [ "k-framework.cachix.org-1:jeyMXB2h28gpNRjuVkehg+zLj62ma1RnyyopA/20yFE=" ];
   };
 
-  outputs = { self, nixpkgs, flake-utils, kevm, hevm, foundry, echidna, halmos-src, runlim-src }:
+  outputs = { self, nixpkgs, flake-utils, hevm, foundry, echidna, halmos-src, doalarm-src }:
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
-        runlim = pkgs.stdenv.mkDerivation {
-          pname = "runlim";
+        doalarm = pkgs.stdenv.mkDerivation {
+          pname = "doalarm";
           version = "1.0";
+          src = doalarm-src;
           configurePhase = ''
             mkdir -p $out/bin
-            ./configure.sh --prefix=$out/bin
           '';
-          src = runlim-src;
+          makeFlags = ["PREFIX=$(out)"];
+          buildInputs = [ pkgs.coreutils pkgs.gnumake ];
         };
         halmos = pkgs.python3.pkgs.buildPythonApplication rec {
           pname = "halmos";
@@ -57,7 +58,7 @@
             # tools
             halmos
             hevm.packages.${system}.default
-            kevm.packages.${system}.default
+            # kevm.packages.${system}.default
             echidna.packages.${system}.default
             foundry.defaultPackage.${system}
             pkgs.solc
@@ -72,7 +73,7 @@
             pkgs.sqlite-interactive
             pkgs.gnuplot
             pkgs.time
-            runlim
+            doalarm
           ];
         };
       });

--- a/flake.nix
+++ b/flake.nix
@@ -36,7 +36,7 @@
             mkdir -p $out/bin
           '';
           makeFlags = ["PREFIX=$(out)"];
-          buildInputs = [ pkgs.coreutils pkgs.gnumake ];
+          buildInputs = [ pkgs.coreutils pkgs.gnumake pkgs.gcc];
         };
         halmos = pkgs.python3.pkgs.buildPythonApplication rec {
           pname = "halmos";

--- a/flake.nix
+++ b/flake.nix
@@ -5,8 +5,8 @@
     flake-utils.url = "github:numtide/flake-utils";
     nixpkgs.url = "github:nixos/nixpkgs";
 
-    hevm.url = "github:ethereum/hevm";
-    # kevm.url = "github:runtimeverification/evm-semantics";
+    hevm.url = "github:ethereum/hevm/";
+    kevm.url = "github:runtimeverification/evm-semantics";
     foundry.url = "github:shazow/foundry.nix/monthly";
     echidna.url = "github:crytic/echidna";
     halmos-src = {
@@ -58,7 +58,7 @@
             # tools
             halmos
             hevm.packages.${system}.default
-            # kevm.packages.${system}.default
+            kevm.packages.${system}.default
             echidna.packages.${system}.default
             foundry.defaultPackage.${system}
             pkgs.solc

--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,7 @@
     flake-utils.url = "github:numtide/flake-utils";
     nixpkgs.url = "github:nixos/nixpkgs";
 
-    hevm.url = "github:ethereum/hevm/";
+    hevm.url = "github:ethereum/hevm";
     kevm.url = "github:runtimeverification/evm-semantics";
     foundry.url = "github:shazow/foundry.nix/monthly";
     echidna.url = "github:crytic/echidna";
@@ -17,12 +17,6 @@
       url = "github:msooseth/doalarm";
       flake = false;
     };
-  };
-
-  nixConfig = {
-    extra-substituters = [ "https://k-framework.cachix.org" ];
-    trusted-substituters = [ "https://k-framework.cachix.org" ];
-    extra-trusted-public-keys = [ "k-framework.cachix.org-1:jeyMXB2h28gpNRjuVkehg+zLj62ma1RnyyopA/20yFE=" ];
   };
 
   outputs = { self, nixpkgs, flake-utils, hevm, kevm, foundry, echidna, halmos-src, doalarm-src }:

--- a/flake.nix
+++ b/flake.nix
@@ -21,10 +21,11 @@
 
   nixConfig = {
     extra-substituters = [ "https://k-framework.cachix.org" ];
+    trusted-substituters = [ "https://k-framework.cachix.org" ];
     extra-trusted-public-keys = [ "k-framework.cachix.org-1:jeyMXB2h28gpNRjuVkehg+zLj62ma1RnyyopA/20yFE=" ];
   };
 
-  outputs = { self, nixpkgs, flake-utils, hevm, foundry, echidna, halmos-src, doalarm-src }:
+  outputs = { self, nixpkgs, flake-utils, hevm, kevm, foundry, echidna, halmos-src, doalarm-src }:
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = nixpkgs.legacyPackages.${system};

--- a/gen_graphs.py
+++ b/gen_graphs.py
@@ -121,7 +121,7 @@ def gen_comparative_graphs() -> None:
             os.system("rm -f \"%s\"" % fname_gnuplot)
             for t in ["eps", "png"]:
                 name = genplot(t)
-                print("generating graph: %s" % name)
+                print("Generating graph: graphs/%s" % name)
             os.system("gnuplot "+fname_gnuplot)
             os.unlink(fname_gnuplot)
 
@@ -166,8 +166,9 @@ def gen_cdf_graph() -> None:
     for fname, _, _ in cdf_files:
         os.unlink(fname)
 
-    print("graph generated: cdf.eps")
-    print("graph generated: cdf.png")
+    print("graph generated: graphs/cdf.eps")
+    print("graph generated: graphs/cdf.png")
+
 
 def check_all_same_tout() -> None:
     with sqlite3.connect("results.db") as cur:
@@ -176,8 +177,8 @@ def check_all_same_tout() -> None:
         from results
         group by tout""")
         touts = []
-        for l in ret:
-            touts.append(l[0])
+        for line in ret:
+            touts.append(line[0])
 
     if len(touts) > 1:
         print("ERROR. Some systems were ran with differing timeouts: ")
@@ -241,7 +242,7 @@ def gen_boxgraphs() -> None:
             elif t == "png":
                 f.write("set term pngcairo font \"Arial,9\" size 1800,900\n")
             f.write("set output \"graphs/boxchart.{t}\"\n".format(t=t))
-            print("Generating boxchart.{t}".format(t=t))
+            print("Generating graphs/boxchart.{t}".format(t=t))
             f.write("set boxwidth {w}\n".format(w=str(w)))
             f.write("set style fill solid\n")
             f.write("set xtics rotate by -45\n")
@@ -277,7 +278,7 @@ def main() -> None:
         os.mkdir("graphs")
     except FileExistsError:
         pass
-    check_all_same_tout();
+    check_all_same_tout()
     gen_cdf_graph()
     gen_comparative_graphs()
     gen_boxgraphs()

--- a/gen_graphs.py
+++ b/gen_graphs.py
@@ -79,7 +79,7 @@ def gen_comparative_graphs() -> None:
             else:
                 assert False
 
-            f.write("set output \""+fname+"\"\n")
+            f.write("set output \"graphs/"+fname+"\"\n")
             f.write("set notitle\n")
             f.write("set nokey\n")
             f.write("set logscale x\n")
@@ -144,7 +144,7 @@ def gen_cdf_graph() -> None:
             else:
                 assert False
 
-            f.write("set output \"cdf.%s\"\n" % t)
+            f.write("set output \"graphs/cdf.%s\"\n" % t)
             f.write("set title \"Solvers\"\n")
             f.write("set notitle\n")
             f.write("set key bottom right\n")
@@ -240,7 +240,7 @@ def gen_boxgraphs() -> None:
                 f.write("set term postscript eps color lw 1 \"Helvetica\" 6 size 8,3\n")
             elif t == "png":
                 f.write("set term pngcairo font \"Arial,9\" size 1800,900\n")
-            f.write("set output \"boxchart.{t}\"\n".format(t=t))
+            f.write("set output \"graphs/boxchart.{t}\"\n".format(t=t))
             print("Generating boxchart.{t}".format(t=t))
             f.write("set boxwidth {w}\n".format(w=str(w)))
             f.write("set style fill solid\n")

--- a/tools/halmos.sh
+++ b/tools/halmos.sh
@@ -6,8 +6,9 @@ contract_file="$1" ; shift
 contract_name="$1" ; shift
 fun_name="$1"; shift
 ds_test="$1"; shift
+tout="$1"; shift
 
-out=$(halmos --ignore-compile --foundry-ignore-compile --function "${fun_name}" --contract "${contract_name}" "$@" 2>&1)
+out=$(doalarm -t real "${tout}" halmos --ignore-compile --foundry-ignore-compile --function "${fun_name}" --contract "${contract_name}" "$@" 2>&1)
 
 set +x
 

--- a/tools/halmos.sh
+++ b/tools/halmos.sh
@@ -8,7 +8,7 @@ fun_name="$1"; shift
 ds_test="$1"; shift
 tout="$1"; shift
 
-out=$(doalarm -t real "${tout}" halmos --ignore-compile --foundry-ignore-compile --function "${fun_name}" --contract "${contract_name}" "$@" 2>&1)
+out=$(doalarm -t real "${tout}" halmos --function "${fun_name}" --contract "${contract_name}" "$@" 2>&1)
 
 set +x
 

--- a/tools/hevm.sh
+++ b/tools/hevm.sh
@@ -13,9 +13,9 @@ source "$SCRIPT_DIR/utils.sh"
 
 if [[ "${ds_test}" == "0" ]]; then
     code=$(get_runtime_bytecode "${contract_file}" "${contract_name}")
-    out=$(doalarm -t alarm "${tout}" hevm symbolic --code "${code}" "$@")
+    out=$(doalarm -t real "${tout}" hevm symbolic --code "${code}" "$@")
 elif [[ "${ds_test}" == "1" ]]; then
-    out=$(doalarm -t alarm "${tout}" hevm test --match "${contract_file}.*${fun_name}" "$@")
+    out=$(doalarm -t real "${tout}" hevm test --match "${contract_file}.*${fun_name}" "$@")
 else
     echo "Called incorrectly"
     exit 1

--- a/tools/hevm.sh
+++ b/tools/hevm.sh
@@ -6,15 +6,16 @@ contract_file="$1" ; shift
 contract_name="$1" ; shift
 fun_name="$1"; shift
 ds_test="$1"; shift
+tout="$1"; shift
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 source "$SCRIPT_DIR/utils.sh"
 
 if [[ "${ds_test}" == "0" ]]; then
     code=$(get_runtime_bytecode "${contract_file}" "${contract_name}")
-    out=$(hevm symbolic --code "${code}" "$@")
+    out=$(doalarm -t alarm "${tout}" hevm symbolic --code "${code}" "$@")
 elif [[ "${ds_test}" == "1" ]]; then
-    out=$(hevm test --match "${contract_file}.*${fun_name}" "$@")
+    out=$(doalarm -t alarm "${tout}" hevm test --match "${contract_file}.*${fun_name}" "$@")
 else
     echo "Called incorrectly"
     exit 1

--- a/tools/hevm_version.sh
+++ b/tools/hevm_version.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
 
 ver=$(hevm version 2>/dev/null)
-echo "${ver}"
+verclean=$(echo "${ver}" | awk '{print $1}')
+echo "${verclean}"

--- a/tools/kevm.sh
+++ b/tools/kevm.sh
@@ -4,10 +4,13 @@ set -euo pipefail
 
 contract_file="$1" ; shift
 contract_name="$1" ; shift
+fun_name="$1"; shift
+ds_test="$1"; shift
+tout="$1"; shift
 
 contract_dir="$(dirname "${contract_file}")"
 contract_k="${contract_dir}/.k-artifacts/bin-runtime.k"
 mkdir -p "$(dirname "${contract_k}")"
 
-kevm solc-to-k "${contract_file}" "${contract_name}" > "${contract_k}"
+doalarm -t alarm "${tout}" kevm solc-to-k "${contract_file}" "${contract_name}" > "${contract_k}"
 cat "${contract_k}"


### PR DESCRIPTION
This branch:
* moves to `doalarm` which should be POSIX-compatible and hence work on Mac.
* puts graphs in the right place
* moves to newer halmos
* removes need for crytic compile
* Allows `check` prefix as used in some halmos test suits
* cleans up code
* fixes up nix cache for kevm