### PR TITLE
Fixes some test case checks for Halmos and HEVM

### DIFF
--- a/tools/halmos.sh
+++ b/tools/halmos.sh
@@ -26,6 +26,10 @@ fi
 
 set +x
 
+if [[ $out =~ "WARNING:Halmos:Counterexample: unknown" ]]; then
+  exit 1
+fi
+
 if [[ $out =~ "Traceback" ]]; then
   exit 1
 fi

--- a/tools/hevm.sh
+++ b/tools/hevm.sh
@@ -37,6 +37,11 @@ fi
 
 set +x
 
+if [[ $out =~ "No reachable assertion violations, but all branches reverted" ]]; then
+    echo "result: safe"
+    exit 0
+fi
+
 if [[ $out =~ "[FAIL]" ]]; then
   echo "result: unsafe"
   exit 0


### PR DESCRIPTION
Two cases are fixed:
* HEVM only prints `[FAIL]` for usability reasons when all branches revert. However, all-revert is a `[PASS]` from the perspective of benchmarking.
* Whenever Halmos prints a so-called unknown Cex, we should consider that a failure of solving [1]

Fixing the corresponding scripts to account for this.

[1] This looks like:

```
WARNING:Halmos:Counterexample: unknown
(see https://github.com/a16z/halmos/wiki/warnings#counterexample-unknown)
```

Where that link explains that the solver didn't terminate, so a `[PASS]` here is not known and I believe it should not be accepted as as point for Halmos.