### PR TITLE
Adding --dumpsmt option to dump all SMT queries

### DIFF
--- a/bench.py
+++ b/bench.py
@@ -239,7 +239,7 @@ def execute_case(tool: str, extra_opts: list[str], case: Case) -> Result:
     fname_time = unique_file("output")
     toexec = ["time", "--verbose", "-o", "%s" % fname_time,
               tool, case.sol_file, case.contract, case.fun, case.sig,
-              "%i" % case.ds, "%s" % opts.timeout, "%s" % (opts.memoutMB)]
+              "%i" % case.ds, "%s" % opts.timeout, "%s" % (opts.memoutMB), "%d" % (opts.dump_smt)]
     toexec.extend(extra_opts)
     print("Running: %s" % (" ".join(toexec)))
     res = subprocess.run(toexec, capture_output=True, encoding="utf-8")
@@ -390,6 +390,9 @@ def set_up_parser() -> optparse.OptionParser:
 
     parser.add_option("--solcv", dest="solc_version", type=str, default="0.8.19",
                       help="solc version to use to compile contracts")
+
+    parser.add_option("--dumpsmt", dest="dump_smt", default=False,
+                      action="store_true", help="Ask the solver to dump SMT files, if the solver supports it")
 
     parser.add_option("-t", dest="timeout", type=int, default=25,
                       help="Max time to run. Default: %default")

--- a/tools/halmos.sh
+++ b/tools/halmos.sh
@@ -24,11 +24,11 @@ out=$(runlim --real-time-limit="${tout}" --kill-delay=2 --space-limit="${memout}
 # directory based on the contract file & name
 set +x
 if [[ "$dump_smt" == "1" ]] && [[ "$out" =~ "Generating SMT" ]]; then
-    a="s/^Generating SMT queries in \\(.*\\)/\\1/"
-    outdir=$(echo "$out" | grep "Generating SMT" | sed -e "${a}")
-    dir="halmos-smt2/${contract_file}.${contract_name}/"
+    regexp="s/^Generating SMT queries in \\(.*\\)/\\1/"
+    smtdir=$(echo "$out" | grep "Generating SMT" | sed -e "${regexp}")
+    outdir="halmos-smt2/${contract_file}.${contract_name}/"
     mkdir -p "$dir"
-    mv -f ${outdir}/*.smt2 "$dir/"
+    mv -f ${smtdir}/*.smt2 "${outdir}/"
 fi
 
 if [[ $out =~ "WARNING:Halmos:Counterexample: unknown" ]]; then

--- a/tools/halmos.sh
+++ b/tools/halmos.sh
@@ -20,7 +20,6 @@ fi
 
 out=$(runlim --real-time-limit="${tout}" --kill-delay=2 --space-limit="${memout}" halmos --function "${fun_name}" --contract "${contract_name}" ${extra_params} "$@" 2>&1)
 
-
 # Check if we emitted smt2 files. If so, copy them over to a
 # directory based on the contract file & name
 set +x

--- a/tools/halmos.sh
+++ b/tools/halmos.sh
@@ -14,7 +14,6 @@ dump_smt="$1"; shift
 extra_params=""
 if [[ "$dump_smt" == "1" ]]; then
     extra_params="${extra_params} --dump-smt-queries"
-    rm -f ./*.smt2
 fi
 
 

--- a/tools/halmos.sh
+++ b/tools/halmos.sh
@@ -30,7 +30,6 @@ if [[ "$dump_smt" == "1" ]] && [[ "$out" =~ "Generating SMT" ]]; then
     dir="halmos-smt2/${contract_file}.${contract_name}/"
     mkdir -p "$dir"
     mv -f ${outdir}/*.smt2 "$dir/"
-    set -x
 fi
 
 if [[ $out =~ "WARNING:Halmos:Counterexample: unknown" ]]; then

--- a/tools/hevm.sh
+++ b/tools/hevm.sh
@@ -32,7 +32,6 @@ else
     exit 1
 fi
 
-
 # Check if we emitted smt2 files. If so, copy them over to a
 # directory based on the contract file & name
 if [[ "$dump_smt" == "1" ]]; then

--- a/tools/hevm.sh
+++ b/tools/hevm.sh
@@ -14,10 +14,10 @@ dump_smt="$1"; shift
 extra_params=""
 if [[ "$dump_smt" == "1" ]]; then
     extra_params="${extra_params} --smtdebug"
+    rm -f ./*.smt2
 fi
 
 
-rm -f ./*.smt2
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 source "$SCRIPT_DIR/utils.sh"


### PR DESCRIPTION
Adding `--dumpsmt` option to dump all SMT queries by both halmos and hevm. halmos currently only dumps SAT queries, I am making a feature request to halmos right now and will link it here.

Created issue in halmos https://github.com/a16z/halmos/issues/248 to generate all SMT files, not just SAT