### PR TITLE
Upgrade forge, and add --ast to `forge build`

### DIFF
--- a/bench.py
+++ b/bench.py
@@ -26,7 +26,7 @@ def build_forge() -> None:
     if not opts.norebuild:
         print("Building with forge...")
         recreate_out()
-        cmd_line = ["forge", "build",
+        cmd_line = ["forge", "build", "--ast",
                    "--extra-output", "storageLayout", "metadata"]
         if opts.yul: cmd_line.extend(["--extra-output", "ir"])
         cmd_line.extend(["--use", opts.solc_version])
@@ -182,6 +182,8 @@ def gather_cases() -> list[Case]:
             if json_path.startswith("out/build-info"):
                 continue
             with open(json_path) as oj:
+                if opts.verbose:
+                    print("Parsing: ", json_path)
                 js = json.load(oj)
                 sol_file: str = js["ast"]["absolutePath"]
                 if sol_file.startswith("src/common/") or sol_file.startswith("lib/"):

--- a/flake.lock
+++ b/flake.lock
@@ -365,11 +365,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1691140388,
-        "narHash": "sha256-AH3fx2VFGPRSOjnuakab4T4AdUstwTnFTbnkoU4df8Q=",
+        "lastModified": 1722676286,
+        "narHash": "sha256-wEDJdvwRZF2ErQ33nQ0Lqn/48XrPbaadv56/bM2MSZU=",
         "owner": "shazow",
         "repo": "foundry.nix",
-        "rev": "6089aad0ef615ac8c7b0c948d6052fa848c99523",
+        "rev": "d84c83b1c1722c8742b3d2d84c9386814d75384e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
We need the `--ast` flag given the new `forge`.